### PR TITLE
ci: shard command_test so compat-offline-core can finish

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -169,12 +169,22 @@ jobs:
 
     runs-on: [self-hosted]
 
+    # Below GitHub's 360-minute default so an overrun fails as a timeout with
+    # the log intact, rather than being reaped at the platform cap.
+    timeout-minutes: 350
+
     env:
       CARGO_TERM_COLOR: always
       RUSTUP_TOOLCHAIN: stable
       LIBRA_SKIP_WEB_BUILD: "1"
       CARGO_PROFILE_TEST_DEBUG: "0"
       CARGO_BUILD_JOBS: "1"
+      # libtest runs each test in a thread with a 2 MiB stack. An unoptimized
+      # async state machine — `switch::execute` and friends inline every
+      # awaited future into one frame — does not fit, and the test process
+      # ABORTS rather than failing. The real CLI runs those futures on the
+      # 8 MiB main thread, so this is a harness limit, not a product one.
+      RUST_MIN_STACK: "16777216"
 
     steps:
       - name: Checkout repository
@@ -240,7 +250,45 @@ jobs:
           LIBRA_STORAGE_BUCKET: ${{ secrets.LIBRA_STORAGE_BUCKET }}
           LIBRA_STORAGE_ACCESS_KEY: ${{ secrets.LIBRA_STORAGE_ACCESS_KEY }}
           LIBRA_STORAGE_SECRET_KEY: ${{ secrets.LIBRA_STORAGE_SECRET_KEY }}
-        run: cargo test --all
+        run: |
+          set -euo pipefail
+          # `cargo test --all` minus the `command_test` binary, which
+          # `compat-offline-command` shards instead. That one target compiles
+          # 150 modules (~2950 tests) into a SINGLE process, and roughly a
+          # third of them serialize on the process-global cwd lock that every
+          # `ChangeDirGuard` takes — so it runs at about one core regardless of
+          # the machine. It went past the 360-minute cap the first time the lib
+          # suite stopped failing early and cargo actually reached it.
+          #
+          # Coverage is unchanged: lib, bins and doctests run here, so does
+          # every other integration target, and `command_test` runs there.
+          #
+          # Targets whose `required-features` are not enabled are dropped, not
+          # named: `cargo test --all` SKIPS those silently, but naming one with
+          # `--test` is a hard error. The later steps in this job run each of
+          # them explicitly with the feature it needs.
+          mapfile -t TARGETS < <(
+            cargo metadata --no-deps --format-version 1 \
+              | jq -r '.packages[]
+                       | (.features.default // []) as $default
+                       | .targets[]
+                       | select(.kind[] == "test")
+                       | select(.name != "command_test")
+                       | select(((((."required-features") // []) - $default) | length) == 0)
+                       | .name' \
+              | sort -u
+          )
+          if [ "${#TARGETS[@]}" -lt 100 ]; then
+            echo "::error::enumerated only ${#TARGETS[@]} integration targets; refusing to run a truncated suite"
+            exit 1
+          fi
+          echo "running lib + bins + doctests + ${#TARGETS[@]} integration targets"
+          ARGS=()
+          for target in "${TARGETS[@]}"; do
+            ARGS+=(--test "$target")
+          done
+          cargo test --lib --bins "${ARGS[@]}"
+          cargo test --doc
 
       # Phase 6 — Local TUI Automation Control scenario suite (docs/improvement/agent.md Part C).
       # Without `--features test-provider` + `LIBRA_ENABLE_TEST_PROVIDER=1`, the scenarios
@@ -302,6 +350,92 @@ jobs:
           path: target/code-ui-scenarios/**
           if-no-files-found: ignore
           retention-days: 7
+
+  # The `command_test` half of what `cargo test --all` used to do in one job.
+  # See the note on compat-offline-core's test step for why it is split out:
+  # the binary is lock-bound rather than CPU-bound, so the only thing that
+  # shortens it is running it in more than one PROCESS. Shards are separate
+  # jobs, so each gets its own cwd lock and they scale with the runner pool.
+  command-tests:
+    name: compat-offline-command
+
+    runs-on: [self-hosted]
+
+    timeout-minutes: 350
+
+    strategy:
+      # One shard failing must not cancel the others: the point of the split is
+      # to see the whole binary's result in one run.
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+
+    env:
+      CARGO_TERM_COLOR: always
+      RUSTUP_TOOLCHAIN: stable
+      LIBRA_SKIP_WEB_BUILD: "1"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_BUILD_JOBS: "1"
+      # See compat-offline-core: 2 MiB test threads cannot hold an
+      # unoptimized async state machine, and the process aborts if one
+      # overflows. `command::switch_test` needs a little over 2 MiB.
+      RUST_MIN_STACK: "16777216"
+      # Kept in one place so the matrix above and the partition below cannot
+      # disagree — a mismatch would silently drop or double-run tests.
+      SHARD_COUNT: "4"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.10.0 --activate
+
+      - name: Run command_test shard ${{ matrix.shard }}
+        env:
+          LIBRA_TEST_GITHUB_TOKEN: ${{ secrets.LIBRA_TEST_GITHUB_TOKEN }}
+          LIBRA_TEST_GITHUB_NAMESPACE: ${{ secrets.LIBRA_TEST_GITHUB_NAMESPACE }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          LIBRA_D1_ACCOUNT_ID: ${{ secrets.LIBRA_D1_ACCOUNT_ID }}
+          LIBRA_D1_API_TOKEN: ${{ secrets.LIBRA_D1_API_TOKEN }}
+          LIBRA_D1_DATABASE_ID: ${{ secrets.LIBRA_D1_DATABASE_ID }}
+          LIBRA_STORAGE_ENDPOINT: ${{ secrets.LIBRA_STORAGE_ENDPOINT }}
+          LIBRA_STORAGE_BUCKET: ${{ secrets.LIBRA_STORAGE_BUCKET }}
+          LIBRA_STORAGE_ACCESS_KEY: ${{ secrets.LIBRA_STORAGE_ACCESS_KEY }}
+          LIBRA_STORAGE_SECRET_KEY: ${{ secrets.LIBRA_STORAGE_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          # Partition by ENUMERATED TEST NAME, not by module prefix. The modulo
+          # split is exhaustive and disjoint by construction, so a renamed or
+          # newly added test cannot silently fall out of every shard the way a
+          # hand-maintained filter list would eventually let one do.
+          cargo test --test command_test --no-run
+          mapfile -t ALL < <(
+            cargo test --test command_test -- --list --format terse \
+              | sed -n 's/: test$//p' | sort
+          )
+          total=${#ALL[@]}
+          if [ "$total" -lt 2000 ]; then
+            echo "::error::enumerated only $total command tests; refusing to run a truncated shard"
+            exit 1
+          fi
+          MINE=()
+          for index in "${!ALL[@]}"; do
+            if [ "$(( index % SHARD_COUNT ))" -eq "${{ matrix.shard }}" ]; then
+              MINE+=("${ALL[$index]}")
+            fi
+          done
+          echo "shard ${{ matrix.shard }} of $SHARD_COUNT: ${#MINE[@]} of $total tests"
+          cargo test --test command_test -- --exact "${MINE[@]}"
 
   network-remotes:
     name: compat-network-remotes


### PR DESCRIPTION
## 背景

`compat-offline-core` **已经数周没有完整跑完过**。`cargo test --all` 是 fail-fast 的，而 lib 套件自 2026-07-28 起一直有失败，cargo 每次都在 lib 阶段中止，**一个集成测试二进制都没跑到过**。表面上看是「53 分钟后失败」，实际上它背后的整个集成套件从未被测量。

把 lib 的失败在一个分支上修好之后，这个 job 直接顶破了 GitHub 的 360 分钟平台上限。随后暴露出三个彼此独立的问题——每一个都是「跑得比以往任何一次都远」才看得见的：

## 三个问题与修法

### 1. `command_test` 是锁瓶颈，不是算力瓶颈

`tests/command_test.rs` 把 150 个模块（约 2950 条测试）编进**一个**二进制——这是有意为之，为了省下「每个命令一个二进制」的编译开销。但其中约三分之一会去抢 `ChangeDirGuard` 持有的那把进程级 cwd 锁，于是无论机器多少核，它实际都只跑在一个核上：日志里 **479 条测试单条超过 60 秒**，而同期宿主机 load 只有 0.3。

加核没用，只有**加进程**有用。所以拆成 `compat-offline-command` 四路矩阵。实测：每片 739 条，约 2h50m，安全落在上限内。

### 2. `switch_test` 栈溢出导致整个二进制 abort

`command::switch_test::test_detach_head_basic` 触发 `fatal runtime error: stack overflow`，整个进程 abort，连 `test result:` 都没有。

**不是递归**：debug 构建下 async 状态机会把每一层 await 的 future 内联进同一个栈帧，`switch::execute` 的调用链装不进 libtest 给测试线程的 2 MiB 栈。隔离单跑可稳定复现：2 MiB 必溢出，4 MiB 稳定通过。这里设 `RUST_MIN_STACK` 为 16 MiB 留足余量。

发布的 CLI 跑在 8 MiB 主线程上，**这是测试框架的限制，不是用户能碰到的产品缺陷**。

### 3. 目标枚举必须过滤 `required-features`

拆分要求 `compat-offline-core` 点名目标而非用 `--all`。但 `required-features` 未启用的目标必须**丢弃**而不能点名：`cargo test --all` 会静默跳过它们，用 `--test <name>` 点名则是硬错误（`target agent_live_gate_test requires the features: test-live-agent`）。

已验证：共 208 个 test target，过滤后 200 个；被丢掉的 8 个正是本 job 后续步骤已经带着各自 feature 显式运行的那些。

## 覆盖面不变

lib、bins、doctests 和其余 200 个集成目标留在 `compat-offline-core`，`command_test` 在分片里跑。

分片按**枚举出的测试名**做取模划分，穷尽且互斥是构造保证的——重命名或新增测试不可能从所有分片里漏掉，而手工维护的过滤名单迟早会漏。本地验证：2956 条，四片各 739，并集去重 2956，交集为空。

两个 job 都会在枚举数异常偏小时**拒绝运行**而不是带着残缺覆盖面通过，并都设了 `timeout-minutes: 350`，让超时以完整日志失败，而不是被平台在 360 分钟处直接砍掉。

## 验证

在 #447 上实测：分片 0 完成 737/739，分片 1 完成 738/739 —— 而在此之前**每一次尝试都是超时或 abort，拿不到任何结果**。剩下的少量失败是既有问题，与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; risk is CI coverage drift if enumeration logic is wrong, mitigated by minimum-count checks and unchanged feature-gated steps.
> 
> **Overview**
> **Splits the monolithic `command_test` run** into a new **`compat-offline-command`** job with a **4-shard matrix** (`fail-fast: false`). Each shard builds `command_test` once, lists every test name, assigns tests by index modulo `SHARD_COUNT`, and runs them with `--exact` so parallel processes avoid the cwd-lock bottleneck that kept a single job on one core past GitHub’s time limit.
> 
> **`compat-offline-core` no longer runs `cargo test --all`.** It runs `--lib`, `--bins`, doctests, and every integration test target except `command_test`, discovered via `cargo metadata` while **dropping targets whose `required-features` are not enabled** (matching `--all`’s silent skip). Feature-gated suites stay on the existing explicit steps. Both jobs set **`timeout-minutes: 350`** and **`RUST_MIN_STACK=16MiB`** so libtest threads don’t abort on large unoptimized async stacks (e.g. `switch_test`).
> 
> **Guardrails:** each job **fails** if enumeration looks truncated (&lt;100 integration targets or &lt;2000 command tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18db9e7a17af0f8b41d0582e39329581864251dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->