### PR TITLE
test: repair the pre-existing compat-offline-core failures

### DIFF
--- a/src/command/rename_detect.rs
+++ b/src/command/rename_detect.rs
@@ -1325,6 +1325,22 @@ impl WorktreeReadBudget {
 mod tests {
     use super::*;
 
+    /// Make `root` discoverable as a repository and step the process cwd into
+    /// it, returning the guard that restores the cwd.
+    ///
+    /// Deliberately NOT a full `libra init`: the worktree read path only needs
+    /// repository DISCOVERY to succeed (`util::working_dir`, for the LFS
+    /// attribute lookup), and a terminal common storage is a gitdir carrying
+    /// the repository database. Standing up a real database here would drag a
+    /// connection pool into a test about byte accounting.
+    fn repo_fixture(root: &Path) -> crate::utils::test::ChangeDirGuard {
+        let gitdir = root.join(crate::utils::util::ROOT_DIR);
+        std::fs::create_dir_all(gitdir.join("objects")).expect("create object store");
+        std::fs::write(gitdir.join(crate::utils::util::DATABASE), b"")
+            .expect("create repository db");
+        crate::utils::test::ChangeDirGuard::new(root)
+    }
+
     fn regular(evidence: BlobEvidence, size: u64) -> BlobRef {
         BlobRef {
             kind: BlobKind::Regular,
@@ -2288,6 +2304,12 @@ mod tests {
         const SHRUNK: u64 = 4;
         const GROWTH: u64 = 4096;
         let dir = tempfile::tempdir().expect("tempdir");
+        // The read path classifies LFS through `attribute_state_for_path`,
+        // which resolves `working_dir()` — infallibly, from the PROCESS cwd,
+        // on the pooled io thread. Outside a repository that panics the
+        // worker and the caller only ever sees the resulting `IoTimeout`,
+        // so the fixture has to be a repository.
+        let _repo = repo_fixture(dir.path());
         let path = dir.path().join("grows.txt");
         std::fs::write(&path, vec![b'a'; (SHRUNK + GROWTH) as usize])
             .expect("write the full-size file");
@@ -2456,6 +2478,11 @@ mod tests {
         use std::time::Duration;
 
         let dir = tempfile::tempdir().expect("tempdir");
+        // See `worktree_total_charges_bytes_read_not_stale_stat`: the LFS
+        // classification resolves `working_dir()` on the io thread, so a
+        // repo-less fixture fails with `IoTimeout` no matter what the seams
+        // are doing — which is precisely the outcome this test denies.
+        let _repo = repo_fixture(dir.path());
         let path = dir.path().join("fast.txt");
         std::fs::write(&path, b"content").expect("write fixture");
 
@@ -2466,8 +2493,21 @@ mod tests {
             std::env::set_var("LIBRA_TEST_SLOW_WORKTREE_READ_MS", "5000");
             std::env::set_var("LIBRA_TEST_SLOW_LFS_ATTRIBUTES_MS", "5000");
         }
-        let mut budget = WorktreeReadBudget::new(1024, 1024, 8, Duration::from_millis(1500));
-        let outcome = budget.read_worktree_blob(&path);
+        // A jammed I/O pool and a fired seam both surface as `IoTimeout`, and
+        // the pool is process-global: the seam tests above abandon reads that
+        // keep sleeping in a worker, and their slots outlive them. So drain
+        // the pool first and retry — with the seams inert one attempt
+        // succeeds as soon as a worker is free, while a 5s seam that really
+        // did fire would blow the 1.5s batch on EVERY attempt.
+        let mut outcome = ContentOutcome::Skipped(SkipReason::IoTimeout);
+        for _ in 0..8 {
+            crate::command::status_probe::wait_for_idle_io_pool();
+            let mut budget = WorktreeReadBudget::new(1024, 1024, 8, Duration::from_millis(1500));
+            outcome = budget.read_worktree_blob(&path);
+            if matches!(outcome, ContentOutcome::Content(_)) {
+                break;
+            }
+        }
         unsafe {
             std::env::remove_var("LIBRA_TEST_SLOW_WORKTREE_STAT_MS");
             std::env::remove_var("LIBRA_TEST_SLOW_WORKTREE_READ_MS");

--- a/src/command/status_probe.rs
+++ b/src/command/status_probe.rs
@@ -129,6 +129,24 @@ static IO_POOL: std::sync::OnceLock<std::sync::Arc<IoWorkerPool>> = std::sync::O
 static IO_BUSY: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 static IO_WORKERS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
+/// Block until every pooled slot has been released.
+///
+/// The deadline tests deliberately ABANDON reads: the caller gives up at its
+/// deadline while the worker keeps sleeping inside the armed seam, and the
+/// slot stays busy until that sleep ends — outliving the test that started
+/// it. A later test whose contract is "this must NOT time out" therefore has
+/// to start from an idle pool, or it measures the previous test's leftover
+/// delay and fails for a reason that has nothing to do with what it asserts.
+#[cfg(test)]
+pub(crate) fn wait_for_idle_io_pool() {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while IO_BUSY.load(std::sync::atomic::Ordering::SeqCst) > 0
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
 /// Run one blocking filesystem operation with a wall-clock deadline.
 ///
 /// A hung syscall cannot be interrupted in safe Rust, so the operation runs

--- a/src/internal/ai/hooks/runtime.rs
+++ b/src/internal/ai/hooks/runtime.rs
@@ -3627,6 +3627,13 @@ mod tests {
         run_builtin_migrations(&conn)
             .await
             .expect("run_builtin_migrations");
+        // `libra init` writes `libra.repoid` as part of bootstrap, and every
+        // ingest path resolves its `CaptureScope` through `RepoIdentity` — a
+        // fixture without it is not a repository this code will write to, it
+        // is one with corrupt metadata.
+        ConfigKv::set_with_conn(&conn, "libra.repoid", "repo-ingest-fixture", false)
+            .await
+            .expect("seed libra.repoid");
         (dir, conn)
     }
 
@@ -3730,8 +3737,13 @@ mod tests {
         )
         .await
         .expect_err("stale hook must not resurrect an erased session");
+        // The tombstone is now enforced inside the scope-claim upsert's WHERE
+        // clause rather than by a separate pre-check, so the refusal surfaces
+        // through the claim diagnostic. The row-count assertion below is the
+        // contract that matters; this one only pins that erasure is named as a
+        // cause rather than the write silently succeeding.
         assert!(
-            err.to_string().contains("anti-resurrection tombstone"),
+            err.to_string().contains("could not be claimed") && err.to_string().contains("erased"),
             "unexpected error: {err:#}"
         );
 
@@ -4153,14 +4165,20 @@ mod tests {
 
     #[tokio::test]
     async fn ingest_fails_loud_when_table_missing() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("noschema.db");
-        std::fs::File::create(&path).expect("touch sqlite file");
-        let url = format!("sqlite://{}", path.display());
-        let mut opts = ConnectOptions::new(url);
-        opts.sqlx_logging(false);
-        let conn = Database::connect(opts).await.expect("connect");
-        // intentionally NOT calling run_builtin_migrations.
+        // A fully bootstrapped repository with exactly ONE table removed. A
+        // schema-less database would fail earlier and for a different reason
+        // (`config_kv` is read first, to resolve the capture scope), which
+        // would leave the claim this test actually makes — that a missing
+        // `agent_session` is reported loudly and by name — untested.
+        let (_dir, conn) = ingest_fresh_conn().await;
+        let backend = conn.get_database_backend();
+        let _: ExecResult = conn
+            .execute_raw(Statement::from_string(
+                backend,
+                "DROP TABLE agent_session".to_string(),
+            ))
+            .await
+            .expect("drop agent_session");
 
         let payload = ingest_envelope("SessionStart", "S-bare", json!({}));
         let err = ingest_agent_traces_payload(

--- a/src/internal/ai/web/mod.rs
+++ b/src/internal/ai/web/mod.rs
@@ -1591,10 +1591,13 @@ mod tests {
 
         use axum::extract::connect_info::MockConnectInfo;
 
+        /// What the adapter recorded, as `(message body, command id)`.
+        type Submitted = Arc<Mutex<Vec<(String, Option<String>)>>>;
+
         #[derive(Clone)]
         struct CommandIdAdapter {
             session: Arc<CodeUiSession>,
-            submitted: Arc<Mutex<Vec<(String, Option<String>)>>>,
+            submitted: Submitted,
         }
 
         #[async_trait::async_trait]

--- a/src/internal/worktree_scope.rs
+++ b/src/internal/worktree_scope.rs
@@ -377,12 +377,37 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn a_pinned_scope_survives_a_cwd_change() {
+        // A REAL repository, because `pin_scope_for_test` resolves its paths
+        // through `RequestScope::resolve` and installs nothing when the
+        // workdir is not inside one — pinning the ambient cwd only appeared to
+        // work when another test had parked it in someone else's fixture.
+        //
+        // Built BEFORE the cwd lock below: `setup_with_new_libra_in` takes and
+        // releases that lock itself, and running a whole `libra init` while
+        // holding it would block every other fixture in the suite for the
+        // duration.
+        let repo = tempfile::tempdir().expect("repo");
+        {
+            let _cd = crate::utils::test::ChangeDirGuard::new(repo.path());
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime")
+                .block_on(crate::utils::test::setup_with_new_libra_in(repo.path()));
+        }
+
+        // Moving the process cwd is not this test's business alone: every
+        // `ChangeDirGuard` in the suite reads the same one. `#[serial]` only
+        // orders this against other `#[serial]` tests, so hold the cwd lock
+        // the guard uses — otherwise the `set_current_dir` below yanks the
+        // directory out from under whatever repository fixture is mid-flight.
+        let _cwd_lock = crate::utils::test::cwd_lock_guard();
         let original = std::env::current_dir().expect("cwd");
         let elsewhere = std::env::temp_dir();
 
         let _pin = WorktreeScope::pin_scope_for_test(
             WorktreeScope::Linked("wt-pinned".to_string()),
-            original.clone(),
+            repo.path().to_path_buf(),
         );
         assert!(WorktreeScope::request_scope_is_pinned());
         assert_eq!(WorktreeScope::for_request().storage_key(), "wt-pinned");
@@ -432,6 +457,10 @@ mod tests {
                 .expect("runtime")
                 .block_on(crate::utils::test::setup_with_new_libra_in(repo.path()));
         }
+        // See `a_pinned_scope_survives_a_cwd_change`: the raw `set_current_dir`
+        // below is process-wide, so it has to hold `ChangeDirGuard`'s lock —
+        // taken only now, so the `libra init` above does not run under it.
+        let _cwd_lock = crate::utils::test::cwd_lock_guard();
         let original = std::env::current_dir().expect("cwd");
 
         // Pin a SUBDIRECTORY, which is what a command invoked from one does.
@@ -483,6 +512,10 @@ mod tests {
                 .expect("runtime")
                 .block_on(crate::utils::test::setup_with_new_libra_in(repo.path()));
         }
+        // See `a_pinned_scope_survives_a_cwd_change`: the raw `set_current_dir`
+        // below is process-wide, so it has to hold `ChangeDirGuard`'s lock —
+        // taken only now, so the `libra init` above does not run under it.
+        let _cwd_lock = crate::utils::test::cwd_lock_guard();
         let original = std::env::current_dir().expect("cwd");
         let canonical_repo =
             std::fs::canonicalize(repo.path()).unwrap_or_else(|_| repo.path().to_path_buf());
@@ -523,11 +556,15 @@ mod tests {
     async fn the_request_database_follows_the_pin_not_the_cwd() {
         let repo_a = tempfile::tempdir().expect("repo a");
         let repo_b = tempfile::tempdir().expect("repo b");
-        let original = std::env::current_dir().expect("cwd");
         for repo in [repo_a.path(), repo_b.path()] {
             let _cd = crate::utils::test::ChangeDirGuard::new(repo);
             crate::utils::test::setup_with_new_libra_in(repo).await;
         }
+        // See `a_pinned_scope_survives_a_cwd_change`: the raw `set_current_dir`
+        // below is process-wide, so it has to hold `ChangeDirGuard`'s lock —
+        // taken only now, so the two `libra init`s above do not run under it.
+        let _cwd_lock = crate::utils::test::cwd_lock_guard();
+        let original = std::env::current_dir().expect("cwd");
 
         let _pin = WorktreeScope::pin_request_scope(repo_a.path().to_path_buf());
         // The cwd is repository B; the pin is repository A.
@@ -576,11 +613,15 @@ mod tests {
         let outer = tempfile::tempdir().expect("the enclosing repository");
         let ambient = tempfile::tempdir().expect("the repository the cwd is in");
         let nowhere = tempfile::tempdir().expect("not a repository");
-        let original = std::env::current_dir().expect("cwd");
         for repo in [outer.path(), ambient.path()] {
             let _cd = crate::utils::test::ChangeDirGuard::new(repo);
             crate::utils::test::setup_with_new_libra_in(repo).await;
         }
+        // See `a_pinned_scope_survives_a_cwd_change`: the raw `set_current_dir`
+        // below is process-wide, so it has to hold `ChangeDirGuard`'s lock —
+        // taken only now, so the two `libra init`s above do not run under it.
+        let _cwd_lock = crate::utils::test::cwd_lock_guard();
+        let original = std::env::current_dir().expect("cwd");
 
         let _outer_pin = WorktreeScope::pin_request_scope(outer.path().to_path_buf());
         std::env::set_current_dir(ambient.path()).expect("move the cwd");

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -98,6 +98,11 @@ mod tests {
         let linked = root.path().join("linked");
         let linked_gitdir = linked.join(".libra");
         fs::create_dir_all(common.join("objects")).expect("create shared object store");
+        // The commondir target must look like TERMINAL common storage
+        // (`util::is_terminal_common_storage`), which an object store alone
+        // does not: a real main gitdir also carries the repository database,
+        // and without it the pointer is refused as corruption.
+        fs::write(common.join(crate::utils::util::DATABASE), b"").expect("create repository db");
         fs::create_dir_all(&linked_gitdir).expect("create linked worktree gitdir");
         fs::write(
             linked_gitdir.join("commondir"),

--- a/tests/data/ai_semantic/rust/sample.rs
+++ b/tests/data/ai_semantic/rust/sample.rs
@@ -1,0 +1,23 @@
+//! Fixture for `tests/ai_semantic_rust_test.rs`. Line numbers are pinned by
+//! that test: `Widget::label` must start on line 10, `make_widget` on 15.
+
+pub struct Widget {
+    name: String,
+}
+
+impl Widget {
+    // Reads the widget's label.
+    fn label(&self) -> &str {
+        &self.name
+    }
+    fn new(name: &str) -> Self { Self { name: name.to_string() } }
+}
+pub fn make_widget(name: &str) -> Widget {
+    Widget::new(name)
+}
+
+fn handle() {}
+
+mod nested {
+    pub fn handle() {}
+}

--- a/tests/data/ai_semantic/rust/tools_sample.rs
+++ b/tests/data/ai_semantic/rust/tools_sample.rs
@@ -1,0 +1,32 @@
+//! Fixture for `tests/ai_semantic_tools_test.rs` (semantic tool handlers).
+//!
+//! Kept separate from `sample.rs`, whose line numbers are pinned by
+//! `tests/ai_semantic_rust_test.rs` — this file's contents matter
+//! (Widget::new + its call site, an ambiguous `handle`), not its line
+//! numbers.
+
+pub struct Widget {
+    name: String,
+}
+
+impl Widget {
+    pub fn new(name: String) -> Self {
+        Widget { name }
+    }
+
+    // Reads the widget's label.
+    fn label(&self) -> &str {
+        &self.name
+    }
+}
+
+pub fn make_widget(name: &str) -> Widget {
+    let name = name.to_string();
+    Widget::new(name)
+}
+
+fn handle() {}
+
+mod nested {
+    pub fn handle() {}
+}


### PR DESCRIPTION
> **堆叠在 #449 之上**。#449 合入后 GitHub 会自动把本 PR 的 base 改回 `main`。
> 之所以堆叠：本 PR 修好 lib 失败后，`cargo test --all` 不再 fail-fast 中止，会继续跑完整个集成套件——如果基于裸 main（无分片），必然重演 360 分钟超时。堆在 #449 上它才跑得完。

## 这些失败都不是新的

它们是**攒出来的**。`cargo test --all` 是 fail-fast：自 2026-07-28 lib 套件开始失败后，每一次运行都在那里中止，下游从来没有被报告过，于是每个新的破坏都无声地叠在上一个之上。

## 修复清单

### 1. 编译期断裂（阻塞所有 PR）

`8f47a4c4` 删掉了 `tests/data/ai_semantic/rust/{sample,tools_sample}.rs`，却留下 `include_str!` 它们的两个测试文件。**main 当前在 `--all-targets` 下无法编译**：

```
error: couldn't read `tests/data/ai_semantic/rust/sample.rs`
error: could not compile `libra` (test "ai_semantic_rust_test")
```

这会让**每一个开着的 PR** 的 `compat-clippy` 失败，不只是本 PR。

选择从 `8f47a4c4^` 原样恢复夹具，而非删掉这两个测试：夹具自己的头部写着 `Line numbers are pinned by that test`，测试里的断言仍在引用那些行号，删测试等于依据一个本该由删除者定夺的判断悄悄退掉活跃覆盖。恢复才是让两半保持自洽的读法。`cargo fmt --all` 不会碰它们（不在模块树里），钉死的行号安全。

### 2. `worktree_scope` 的 cwd 锁（`0ce8f77c`）

五个测试直接调 `std::env::set_current_dir`。`#[serial]` 只与其他 `#[serial]` 测试互斥，与每个 `ChangeDirGuard` 持有的 `CWD_LOCK` 是两套锁，于是它们把进程 cwd 从正在运行的夹具下面抽走——**这正是连带打死 ai/hooks、rename_detect、utils::path 那批测试的原因**。

现在它们持有那把锁，并且在**建完夹具之后**才持有，避免整个 `libra init` 在一把全套件都在等的锁下运行。

`a_pinned_scope_survives_a_cwd_change` 另有一处：它 pin 的是环境 cwd，而 `RequestScope::resolve` 在非仓库目录下不装 pin——它此前只在「偶然抢到别的测试把 cwd 停在某个 libra 夹具里」的瞬间才通过，而那一刻恰恰就是它打死那个测试的一刻。现在给它一个真实仓库。

### 3. `ai/hooks/runtime` 的 `libra.repoid`（`6da73c67`）

`CaptureScope` 接入 ingest 路径后要解析 `RepoIdentity`，但夹具 `ingest_fresh_conn` 从未写入 `libra.repoid`，导致 **14 条测试确定性失败**——单条跑也挂。按 `libra init` 的做法补上种子。

`ingest_fails_loud_when_table_missing` 改为从完整 schema 里删掉**一张**表，而不是从无 schema 的空库开始：否则它会更早地栽在 `config_kv` 上，测不到它自己声称要测的东西。tombstone 测试则改为断言现在承载该拒绝的那条诊断信息。

### 4. `utils/path` 的 commondir 夹具

夹具的 commondir 目标缺少仓库数据库，已不再满足 `is_terminal_common_storage`。

### 5. `rename_detect`（`5c1b7bb2`、`a26cc9ac`）

LFS 分类在池化 io 线程上调用不可失败的 `working_dir()`，在非仓库目录下直接 panic 掉 worker，传到调用方只剩一个语焉不详的 `IoTimeout`。两个测试都给了真实仓库。

另外**池被占满时同样报 `IoTimeout`**——seam 测试会放弃那些仍在 worker 里睡觉的读，槽位活得比测试本身长，而池是进程级的。所以那个反向测试改为先排空池再重试。真正触发了 seam 的话每次重试都会挂，断言的判别力没有削弱。

### 6. `ai/web` 的 `type_complexity`

测试内部适配器字段的复杂类型，改为具名别名，顺带把元组两半的含义写下来。

## 验证

- `cargo test --lib`：**4409 passed / 0 failed**
- `ai_semantic_rust_test` 4 passed、`ai_semantic_tools_test` 5 passed
- `cargo +nightly fmt --all --check` 干净
- `cargo clippy --all-targets --all-features -- -D warnings` 干净

## 不在本 PR 范围内

#447 的分片运行还暴露了若干**产品与测试的契约不一致**，例如只读 DB 导致的失败该报 `LBR-IO-001`（打开失败）还是 `LBR-IO-002`（写失败）、过期租约该返回 403 还是 409。改断言能让它们变绿，但那是在替维护者决定契约，不适合由本 PR 单方面做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and fixture changes with no production logic paths modified; risk is limited to CI signal quality if a fix masks a real bug.
> 
> **Overview**
> Unblocks **`cargo test --all`** by fixing compile breaks, flaky cross-test cwd interference, and outdated test fixtures—not product behavior changes.
> 
> **Restores deleted AI semantic fixtures** (`tests/data/ai_semantic/rust/sample.rs` and `tools_sample.rs`) so integration tests that `include_str!` them and pin line numbers compile again.
> 
> **Serializes worktree scope tests** that call `set_current_dir` by taking `ChangeDirGuard`'s **`cwd_lock_guard`** after fixtures are built (so `libra init` does not hold the suite-wide lock), and gives **`a_pinned_scope_survives_a_cwd_change`** a real repo so pinning is not a false pass on ambient cwd.
> 
> **Hardens rename_detect / status I/O tests**: lightweight **`repo_fixture`** for LFS/`working_dir()` discovery; **`wait_for_idle_io_pool`** plus retry in **`slow_op_seams_are_ignored_without_the_harness_gate`** so a full global I/O pool is not mistaken for fired delay seams.
> 
> **Aligns AI hooks ingest tests** with current contracts: seed **`libra.repoid`** in **`ingest_fresh_conn`**, drop a single table for the missing-table test, and assert tombstone errors via **claim / erased** diagnostics.
> 
> **Fixes `utils/path` linked-worktree fixture** by adding a stub repo DB so commondir targets satisfy terminal common storage. Minor **`ai/web`** test type alias for clippy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8fd5b30c51e0a263798ad7c7bf6d02d29ab246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->