### PR TITLE
Implement Operation Log v2 M2/M3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -613,3 +613,11 @@ path = "tests/operation_dag.rs"
 [[test]]
 name = "workspace_snapshot_roundtrip"
 path = "tests/workspace_snapshot_roundtrip.rs"
+
+[[test]]
+name = "index_snapshot_roundtrip"
+path = "tests/index_snapshot_roundtrip.rs"
+
+[[test]]
+name = "sequencer_snapshot_roundtrip"
+path = "tests/sequencer_snapshot_roundtrip.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -625,3 +625,7 @@ path = "tests/sequencer_snapshot_roundtrip.rs"
 [[test]]
 name = "operation_command_coverage"
 path = "tests/operation_command_coverage.rs"
+
+[[test]]
+name = "agent_shell_operation"
+path = "tests/agent_shell_operation.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -608,3 +608,8 @@ path = "tests/operation_schema_v2.rs"
 [[test]]
 name = "operation_dag"
 path = "tests/operation_dag.rs"
+
+# plan-20260822 OL-05..09: operation-log v2 snapshot and mutation-boundary targets.
+[[test]]
+name = "workspace_snapshot_roundtrip"
+path = "tests/workspace_snapshot_roundtrip.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -621,3 +621,7 @@ path = "tests/index_snapshot_roundtrip.rs"
 [[test]]
 name = "sequencer_snapshot_roundtrip"
 path = "tests/sequencer_snapshot_roundtrip.rs"
+
+[[test]]
+name = "operation_command_coverage"
+path = "tests/operation_command_coverage.rs"

--- a/docs/development/commands/op.md
+++ b/docs/development/commands/op.md
@@ -24,6 +24,23 @@ extension rather than a Git command. The current public surface supports:
 - Operation tables are part of the bootstrap schema and are also ensured by the
   explicit database upgrade path for older repositories.
 
+## Operation Log v2 mutation boundary
+
+The M2/M3 implementation uses the sidecar-only working-copy pointer and does
+not add a `change-id` commit header, rewrite Git commit OIDs, bump versions, or
+create release artifacts. The operation middleware classifies every mutation
+surface as one of `WorkspaceMutation`, `RepoMutation`, `SequencerMutation`,
+`LibraStateMutation`, `ExternalOrUnknown`, `ReadOnly`, or `InternalWorker`.
+Unknown classifications fail closed; read-only commands and internal workers
+do not create operations. Agent shell and external VCS tools must provide
+verified before/after evidence before they can be admitted.
+
+The v2 snapshot facets capture the raw index byte-for-byte together with
+sequencer and sparse-view state. `WorkspaceSnapshotV2` excludes ignored files
+by default and records bounded scans as partial rather than presenting an
+incomplete snapshot as complete. The focused contracts are registered in
+`tests/INDEX.md`; the full restore engine remains OL-10.
+
 ## Current Behavior
 
 - `op log` lists operations by repository with pagination and exact command

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1717,8 +1717,12 @@ fn command_scope(command: &Commands) -> CommandScope {
         // FETCH_HEAD is worktree-local: run from a legacy shared-`.libra`
         // worktree it lands in MAIN's gitdir.
         | Commands::Pull(_)
-        | Commands::Fetch(_)
-        | Commands::Stash(_)
+        | Commands::Fetch(_) => Composite,
+
+        // `stash list/show` only inspect the shared stash namespace; they
+        // must not acquire a writer boundary or create operation-log state.
+        Commands::Stash(Stash::List) | Commands::Stash(Stash::Show { .. }) => ReadOnly,
+        Commands::Stash(_)
         // These run tools that edit the working tree.
         | Commands::Automation(_)
         | Commands::Sandbox(_) => Composite,
@@ -1913,29 +1917,134 @@ fn command_mutates_worktree_state(command: &Commands) -> bool {
 /// mutation classes. `command_scope` remains the authority for coverage: a
 /// newly added `Commands` variant must still be classified there before this
 /// adapter can compile and run.
-fn operation_class_for_command(
-    command: &Commands,
-) -> crate::internal::operation::MutationClass {
+fn operation_class_for_command(command: &Commands) -> crate::internal::operation::MutationClass {
     use crate::internal::operation::MutationClass;
+    // `commit --dry-run` and `commit --porcelain` are previews: the command
+    // deliberately uses ephemeral blob/cache state and promises not to
+    // publish an operation or durable snapshot of its own.
+    if matches!(
+        command,
+        Commands::Commit(args) if args.dry_run || args.porcelain
+    ) {
+        return MutationClass::ReadOnly;
+    }
+    if matches!(command_scope(command), CommandScope::ReadOnly) {
+        return MutationClass::ReadOnly;
+    }
+    // These surfaces either have their own durable boundary or are pure
+    // inspection when the parsed subcommand says so.  In particular, a
+    // read-only hash-object must remain usable from a library/test binary
+    // where the killable CLI worker is intentionally unavailable.
+    if matches!(command, Commands::Fsck(_))
+        || matches!(command, Commands::HashObject(args) if !args.write)
+        || matches!(
+            command,
+            Commands::Cloud(command::cloud::CloudArgs {
+                command: command::cloud::CloudCommand::Status(_),
+            })
+        )
+        || matches!(
+            command,
+            Commands::Cache(command::cache::CacheArgs {
+                command: command::cache::CacheCommand::Info,
+            })
+        )
+    {
+        return MutationClass::ReadOnly;
+    }
     match command {
+        Commands::Config(args) if config_command_is_read_only(args) => MutationClass::ReadOnly,
+        Commands::Agent(args) if agent_command_is_read_only(args) => MutationClass::ReadOnly,
         Commands::Merge(_)
         | Commands::Rebase(_)
         | Commands::CherryPick(_)
         | Commands::Revert(_)
         | Commands::Am(_)
         | Commands::Bisect(_) => MutationClass::SequencerMutation,
-        Commands::Worktree(_)
-        | Commands::SparseView(_)
-        | Commands::Layer(_)
-        | Commands::Dirty(_)
-        | Commands::Automation(_)
-        | Commands::Agent(_) => MutationClass::LibraStateMutation,
+        Commands::Worktree(_) | Commands::SparseView(_) | Commands::Layer(_) => {
+            MutationClass::LibraStateMutation
+        }
+        Commands::Dirty(args) if args.list => MutationClass::ReadOnly,
+        Commands::Dirty(_) => MutationClass::LibraStateMutation,
+        Commands::Automation(args) => match args.command {
+            command::automation::AutomationSubcommand::List
+            | command::automation::AutomationSubcommand::History { .. } => MutationClass::ReadOnly,
+            command::automation::AutomationSubcommand::Run { live: true, .. } => {
+                MutationClass::ExternalOrUnknown
+            }
+            command::automation::AutomationSubcommand::Run { .. } => {
+                MutationClass::LibraStateMutation
+            }
+        },
+        Commands::Agent(_) | Commands::Review(_) | Commands::Investigate(_) | Commands::Code(_) => {
+            MutationClass::LibraStateMutation
+        }
         _ => match command_scope(command) {
             CommandScope::ReadOnly => MutationClass::ReadOnly,
             CommandScope::Worktree => MutationClass::WorkspaceMutation,
             CommandScope::Repository | CommandScope::Composite => MutationClass::RepoMutation,
         },
     }
+}
+
+/// Commands with a pre-existing operation boundary must not be wrapped a
+/// second time by the CLI adapter.  The legacy wrapper is intentionally kept
+/// for OL-15 compatibility, while the Agent gateway owns its own boundary;
+/// nesting either wrapper would take two leases and can deadlock a command
+/// that legitimately invokes another Libra operation.
+fn command_has_existing_operation_boundary(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Branch(_)
+            | Commands::Op(_)
+            | Commands::Config(_)
+            | Commands::Worktree(_)
+            | Commands::ReadTree(_)
+            | Commands::Merge(_)
+            | Commands::Rebase(_)
+            | Commands::CherryPick(_)
+            | Commands::Revert(_)
+            | Commands::Am(_)
+            | Commands::Bisect(_)
+            | Commands::Repack(_)
+            | Commands::Maintenance(_)
+            | Commands::File(_)
+            | Commands::HashObject(_)
+            | Commands::IndexPack(_)
+            | Commands::Service(_)
+            | Commands::Code(_)
+            | Commands::Agent(_)
+            | Commands::Review(_)
+            | Commands::Investigate(_)
+    )
+}
+
+fn config_command_is_read_only(args: &command::config::ConfigArgs) -> bool {
+    args.get
+        || args.get_all
+        || args.list
+        || args.get_regexp
+        || args.show_origin
+        || matches!(
+            &args.command,
+            Some(
+                command::config::ConfigCommand::Get { .. }
+                    | command::config::ConfigCommand::List { .. }
+                    | command::config::ConfigCommand::Path
+                    | command::config::ConfigCommand::Edit
+            )
+        )
+}
+
+fn agent_command_is_read_only(args: &command::agent::AgentArgs) -> bool {
+    matches!(
+        &args.command,
+        command::agent::AgentSubcommand::Status(_)
+            | command::agent::AgentSubcommand::List(_)
+            | command::agent::AgentSubcommand::Graph(_)
+            | command::agent::AgentSubcommand::Skill(_)
+            | command::agent::AgentSubcommand::Workspace(_)
+    )
 }
 
 /// Does this command hold the SHARED maintenance lock for its whole run
@@ -2583,7 +2692,18 @@ async fn parse_async_scoped(argv: Vec<std::ffi::OsString>) -> CliResult<()> {
     // is owned by the command/Agent boundary; keeping this call at the
     // central parse seam prevents a new surface from bypassing classification.
     let operation_class = operation_class_for_command(&args.command);
-    tracing::debug!(?operation_class, "classified CLI operation mutation surface");
+    let use_central_operation_boundary = !command_has_existing_operation_boundary(&args.command);
+    // Read-only commands must not charge their census diagnostic to the
+    // active logfile; `logfile info` reports rolled-file sizes exactly.
+    if !matches!(
+        operation_class,
+        crate::internal::operation::MutationClass::ReadOnly
+    ) {
+        tracing::debug!(
+            ?operation_class,
+            "classified CLI operation mutation surface"
+        );
+    }
     if let Commands::Diff(diff_args) = &mut args.command {
         command::diff::record_algorithm_selector_events(diff_args, &utf8_argv);
     }
@@ -2776,7 +2896,14 @@ async fn parse_async_scoped(argv: Vec<std::ffi::OsString>) -> CliResult<()> {
         None => None,
     };
 
-    let command_result: CliResult<()> = async {
+    let remote_prune_name = match &args.command {
+        Commands::Remote(command::remote::RemoteCmds::Prune {
+            name,
+            dry_run: false,
+        }) => Some(name.clone()),
+        _ => None,
+    };
+    let command_future = async {
         match args.command {
             Commands::Init(cmd_args) => {
                 let original_dir = utils::util::cur_dir();
@@ -3026,8 +3153,46 @@ async fn parse_async_scoped(argv: Vec<std::ffi::OsString>) -> CliResult<()> {
             }
         }
         Ok(())
-    }
-    .await;
+    };
+    let command_result: CliResult<()> = if let Some(scope) =
+        crate::internal::worktree_scope::WorktreeScope::request_scope()
+        && !matches!(
+            operation_class,
+            crate::internal::operation::MutationClass::ReadOnly
+                | crate::internal::operation::MutationClass::InternalWorker
+        )
+        && use_central_operation_boundary
+    {
+        let command_name = utf8_argv
+            .iter()
+            .skip(1)
+            .find(|argument| !argument.starts_with('-'))
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let meta = crate::internal::operation::OperationMetaV2 {
+            command_name: Some(command_name),
+            description: Some("CLI mutation".to_string()),
+            ..Default::default()
+        };
+        let outcome = crate::internal::operation::run_with_operation(
+            &scope,
+            meta,
+            operation_class,
+            |_txn| async move {
+                command_future
+                    .await
+                    .map_err(crate::internal::operation::OperationError::Cli)
+            },
+        )
+        .await;
+        match outcome {
+            Ok(_) => Ok(()),
+            Err(crate::internal::operation::OperationError::Cli(error)) => Err(error),
+            Err(error) => Err(operation_error_to_cli(error, remote_prune_name.as_deref())),
+        }
+    } else {
+        command_future.await
+    };
 
     background_index_guard.finish().await;
 
@@ -3059,6 +3224,28 @@ async fn parse_async_scoped(argv: Vec<std::ffi::OsString>) -> CliResult<()> {
     }
 
     Ok(())
+}
+
+fn operation_error_to_cli(
+    error: crate::internal::operation::OperationError,
+    remote_prune_name: Option<&str>,
+) -> CliError {
+    let detail = error.to_string();
+    let lower = detail.to_ascii_lowercase();
+    if lower.contains("failed to register its cloud object-index repair marker")
+        || lower.contains("object-index repair lock")
+        || lower.contains("readonly database")
+        || lower.contains("read-only database")
+        || lower.contains("database is locked")
+    {
+        let message = remote_prune_name.map_or_else(
+            || detail.clone(),
+            |name| format!("failed to prune remote-tracking branch for remote '{name}': {detail}"),
+        );
+        return CliError::fatal(message)
+            .with_stable_code(crate::utils::error::StableErrorCode::IoWriteFailed);
+    }
+    CliError::fatal(detail)
 }
 
 struct BackgroundIndexDrainGuard {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1909,6 +1909,35 @@ fn command_mutates_worktree_state(command: &Commands) -> bool {
     command_scope(command).mutates_worktree_state()
 }
 
+/// Map the already-exhaustive CLI scope census onto the operation-log v2
+/// mutation classes. `command_scope` remains the authority for coverage: a
+/// newly added `Commands` variant must still be classified there before this
+/// adapter can compile and run.
+fn operation_class_for_command(
+    command: &Commands,
+) -> crate::internal::operation::MutationClass {
+    use crate::internal::operation::MutationClass;
+    match command {
+        Commands::Merge(_)
+        | Commands::Rebase(_)
+        | Commands::CherryPick(_)
+        | Commands::Revert(_)
+        | Commands::Am(_)
+        | Commands::Bisect(_) => MutationClass::SequencerMutation,
+        Commands::Worktree(_)
+        | Commands::SparseView(_)
+        | Commands::Layer(_)
+        | Commands::Dirty(_)
+        | Commands::Automation(_)
+        | Commands::Agent(_) => MutationClass::LibraStateMutation,
+        _ => match command_scope(command) {
+            CommandScope::ReadOnly => MutationClass::ReadOnly,
+            CommandScope::Worktree => MutationClass::WorkspaceMutation,
+            CommandScope::Repository | CommandScope::Composite => MutationClass::RepoMutation,
+        },
+    }
+}
+
 /// Does this command hold the SHARED maintenance lock for its whole run
 /// (plan-20260714 §C.4.3 writer-vs-deleter)?
 ///
@@ -2549,6 +2578,12 @@ async fn parse_async_scoped(argv: Vec<std::ffi::OsString>) -> CliResult<()> {
             _ => return Err(classify_parse_error(&argv, &err)),
         },
     };
+    // OL-09 census seam: every concrete CLI command is classified before any
+    // dispatch-specific mutation code runs. The actual operation transaction
+    // is owned by the command/Agent boundary; keeping this call at the
+    // central parse seam prevents a new surface from bypassing classification.
+    let operation_class = operation_class_for_command(&args.command);
+    tracing::debug!(?operation_class, "classified CLI operation mutation surface");
     if let Commands::Diff(diff_args) = &mut args.command {
         command::diff::record_algorithm_selector_events(diff_args, &utf8_argv);
     }

--- a/src/command/maintenance.rs
+++ b/src/command/maintenance.rs
@@ -4931,6 +4931,10 @@ mod tests {
                 "the HEAD pointer file (dual-layout compatibility); ref OIDs are inventoried in the DB half (reference)",
             ),
             (
+                "operation-v2.lock",
+                "the cross-process operation middleware lease; it contains no object ids and is never a GC root",
+            ),
+            (
                 "config",
                 "repository configuration file (dual-layout compatibility); no object ids",
             ),

--- a/src/command/remote.rs
+++ b/src/command/remote.rs
@@ -1174,6 +1174,12 @@ async fn run_prune_remote(name: String, dry_run: bool) -> Result<RemoteOutput, R
                     BranchStoreError::Corrupt { name, detail } => {
                         RemoteError::BranchCorrupt { name, detail }
                     }
+                    BranchStoreError::Query(detail) if branch_delete_write_failure(&detail) => {
+                        RemoteError::BranchDelete {
+                            name: entry.remote_ref.clone(),
+                            detail,
+                        }
+                    }
                     BranchStoreError::Query(detail) => RemoteError::BranchList { detail },
                     other => RemoteError::ConfigWrite {
                         detail: other.to_string(),
@@ -1187,6 +1193,14 @@ async fn run_prune_remote(name: String, dry_run: bool) -> Result<RemoteOutput, R
         dry_run,
         stale_branches,
     })
+}
+
+fn branch_delete_write_failure(detail: &str) -> bool {
+    let detail = detail.to_ascii_lowercase();
+    detail.contains("readonly")
+        || detail.contains("read-only")
+        || detail.contains("permission denied")
+        || detail.contains("database is locked")
 }
 
 /// A remote is considered to exist if **any** `remote.<name>.*` key is

--- a/src/command/reset.rs
+++ b/src/command/reset.rs
@@ -620,11 +620,12 @@ async fn reset_pathspecs(
     pathspecs: &[String],
     target_commit_id: &ObjectHash,
 ) -> Result<Vec<String>, ResetError> {
-    let commit: Commit = load_object(target_commit_id)
-        .map_err(|e| object_load_error("commit", target_commit_id.to_string(), e.to_string()))?;
-
-    let tree: Tree = load_object(&commit.tree_id)
-        .map_err(|e| object_load_error("tree", commit.tree_id.to_string(), e.to_string()))?;
+    // Rebuild the target index before applying pathspecs. Besides providing
+    // the exact target entries, this validates every traversed subtree. A
+    // corrupt nested tree must be reported as repository corruption rather
+    // than being mistaken for a path that should simply be removed from the
+    // current index.
+    let target_index = index_for_commit(target_commit_id)?;
 
     let index_file = path::index();
     let mut index = Index::load(&index_file).map_err(|e| ResetError::IndexLoad(e.to_string()))?;
@@ -646,17 +647,18 @@ async fn reset_pathspecs(
         let path_str = relative_path.to_str().ok_or_else(|| {
             ResetError::InvalidPathspecEncoding(relative_path.display().to_string())
         })?;
-
-        match find_tree_item(&tree, path_str)? {
-            Some(item) => {
-                let blob: git_internal::internal::object::blob::Blob = load_object(&item.id)
-                    .map_err(|e| object_load_error("blob", item.id.to_string(), e.to_string()))?;
+        match target_index.get(path_str, 0) {
+            Some(target_entry) => {
+                let blob: git_internal::internal::object::blob::Blob =
+                    load_object(&target_entry.hash).map_err(|e| {
+                        object_load_error("blob", target_entry.hash.to_string(), e.to_string())
+                    })?;
                 let mut entry = IndexEntry::new_from_blob(
                     path_str.to_string(),
-                    item.id,
+                    target_entry.hash,
                     blob.data.len() as u32,
                 );
-                entry.mode = tree_item_mode_to_index_mode(item.mode)?;
+                entry.mode = target_entry.mode;
                 index.add(entry);
                 changed = true;
                 changed_paths.push(pathspec.clone());

--- a/src/internal/ai/tools/registry.rs
+++ b/src/internal/ai/tools/registry.rs
@@ -288,6 +288,8 @@ impl ToolRegistry {
 
         let mutates_state = handler.is_mutating(&invocation).await;
         let requires_network = handler.requires_network(&invocation).await;
+        let operation_class = operation_class_for_tool(&tool_name, mutates_state);
+        tracing::debug!(?operation_class, tool = %tool_name, "classified Agent tool operation surface");
 
         if let Some(hardening) = &self.hardening {
             let operation = ToolOperation::tool(tool_name.clone(), mutates_state, requires_network);
@@ -432,6 +434,25 @@ fn is_read_only_or_semantic_tool(tool_name: &str) -> bool {
             | "list_tool_invocations"
             | "list_provenances"
     )
+}
+
+/// Central Agent-tool census used by the gateway before handler dispatch.
+/// Read-only tools are never recorded; shell and external VCS calls require
+/// before/after verification; every other mutating tool is conservatively a
+/// Libra-state mutation until it is assigned a narrower owner.
+pub fn operation_class_for_tool(
+    tool_name: &str,
+    mutates_state: bool,
+) -> crate::internal::operation::MutationClass {
+    use crate::internal::operation::MutationClass;
+    if !mutates_state || is_read_only_or_semantic_tool(tool_name) {
+        return MutationClass::ReadOnly;
+    }
+    match tool_name {
+        "shell" | "run_libra_vcs" | "exec" => MutationClass::ExternalOrUnknown,
+        "apply_patch" | "write_file" | "edit_file" => MutationClass::WorkspaceMutation,
+        _ => MutationClass::LibraStateMutation,
+    }
 }
 
 fn rebase_payload_path_aliases(

--- a/src/internal/ai/tools/registry.rs
+++ b/src/internal/ai/tools/registry.rs
@@ -44,7 +44,10 @@ pub trait ToolHandler: Send + Sync {
     /// Returns `true` if the tool invocation *might* mutate the environment.
     /// This function should be defensive and return `true` if there's any doubt.
     async fn is_mutating(&self, _invocation: &ToolInvocation) -> bool {
-        false
+        // The operation boundary is fail-closed: a handler that has not
+        // opted into a narrower read-only classification is treated as
+        // potentially mutating.
+        true
     }
 
     /// Returns `true` if the invocation requires direct network access.
@@ -290,6 +293,126 @@ impl ToolRegistry {
         let requires_network = handler.requires_network(&invocation).await;
         let operation_class = operation_class_for_tool(&tool_name, mutates_state);
         tracing::debug!(?operation_class, tool = %tool_name, "classified Agent tool operation surface");
+
+        // Repository-backed Agent mutations use the same durable v2 boundary
+        // as the CLI. Read-only tools remain direct, while a tool invoked from
+        // a repository that cannot resolve a pinned scope keeps the existing
+        // non-repository behavior (external tools are still subject to the
+        // hardening policy below).
+        if mutates_state
+            && let Some(scope) =
+                crate::internal::worktree_scope::RequestScope::resolve(self.working_dir.clone())
+        {
+            let operation_handler = handler.clone();
+            let operation_hardening = self.hardening.clone();
+            let operation_working_dir = self.working_dir.clone();
+            let operation_aliases = self.path_aliases.clone();
+            let operation_tool_name = tool_name.clone();
+            let operation_meta = crate::internal::operation::OperationMetaV2 {
+                command_name: Some(format!("agent.tool.{operation_tool_name}")),
+                description: Some("Agent tool mutation".to_string()),
+                ..Default::default()
+            };
+            let outcome = crate::internal::operation::run_with_operation(
+                &scope,
+                operation_meta,
+                operation_class,
+                move |_txn| async move {
+                    let result = if let Some(hardening) = operation_hardening {
+                        let operation = ToolOperation::tool(
+                            operation_tool_name.clone(),
+                            mutates_state,
+                            requires_network,
+                        );
+                        let decision = hardening.decide(&operation);
+                        hardening
+                            .append_audit(
+                                format!("tool_boundary.{}", operation_tool_name),
+                                format!(
+                                    "decision={} approval_required={} reason={} payload={}",
+                                    if decision.allowed { "allow" } else { "deny" },
+                                    decision.approval_required,
+                                    decision.reason,
+                                    invocation.log_payload()
+                                ),
+                            )
+                            .await
+                            .map_err(|error| {
+                                crate::internal::operation::OperationError::Mutation(format!(
+                                    "failed to persist tool boundary audit event: {error}"
+                                ))
+                            })?;
+                        if !decision.allowed {
+                            return Err(crate::internal::operation::OperationError::Mutation(
+                                decision.reason,
+                            ));
+                        }
+                        let result = operation_handler.handle(invocation).await.map(|output| {
+                            redact_workspace_paths_in_output(
+                                output,
+                                &operation_working_dir,
+                                &operation_aliases,
+                            )
+                        });
+                        let summary = match &result {
+                            Ok(output) => format!(
+                                "success={} output={}",
+                                output.is_success(),
+                                output.log_preview()
+                            ),
+                            Err(error) => format!("error={error}"),
+                        };
+                        hardening
+                            .append_audit(format!("tool_result.{}", operation_tool_name), summary)
+                            .await
+                            .map_err(|error| {
+                                crate::internal::operation::OperationError::Mutation(format!(
+                                    "failed to persist tool result audit event: {error}"
+                                ))
+                            })?;
+                        hardening.flush_audit().await.map_err(|error| {
+                            crate::internal::operation::OperationError::Mutation(format!(
+                                "failed to flush tool audit sink: {error}"
+                            ))
+                        })?;
+                        result.map_err(|error| {
+                            crate::internal::operation::OperationError::Mutation(error.to_string())
+                        })?
+                    } else {
+                        operation_handler
+                            .handle(invocation)
+                            .await
+                            .map(|output| {
+                                redact_workspace_paths_in_output(
+                                    output,
+                                    &operation_working_dir,
+                                    &operation_aliases,
+                                )
+                            })
+                            .map_err(|error| {
+                                crate::internal::operation::OperationError::Mutation(
+                                    error.to_string(),
+                                )
+                            })?
+                    };
+                    Ok(result)
+                },
+            )
+            .await;
+            return match outcome {
+                Ok(result) => Ok(result.value),
+                Err(error) => Err(ToolError::ExecutionFailed(error.to_string())),
+            };
+        }
+
+        if operation_class == crate::internal::operation::MutationClass::ExternalOrUnknown
+            && self.hardening.is_none()
+        {
+            return Err(ToolError::ExecutionFailed(
+                "external or unknown mutation requires a repository scope and post-snapshot verification"
+                    .to_string(),
+            ));
+        }
 
         if let Some(hardening) = &self.hardening {
             let operation = ToolOperation::tool(tool_name.clone(), mutates_state, requires_network);

--- a/src/internal/operation/facets.rs
+++ b/src/internal/operation/facets.rs
@@ -175,7 +175,11 @@ impl StateFacet for SparseFacet {
         let scope = self.scope.clone();
         run_async(async move {
             let _pin = WorktreeScope::override_scope(scope.workdir.clone());
-            SparseViewStore::replace(&scope.scope, &patterns).await
+            SparseViewStore::replace(&scope.scope, &patterns).await?;
+            if value.get("enabled").and_then(serde_json::Value::as_bool) == Some(false) {
+                SparseViewStore::disable(&scope.scope).await?;
+            }
+            Ok::<_, String>(())
         }).map_err(FacetError::Restore)?
             .map_err(FacetError::Restore)?;
         Ok(())

--- a/src/internal/operation/facets.rs
+++ b/src/internal/operation/facets.rs
@@ -1,0 +1,224 @@
+//! State-facet adapters used by workspace snapshots.
+//!
+//! The adapters keep capture/restore ownership next to the state they know
+//! how to serialize.  They do not implement a restore engine: OL-10 owns the
+//! ordering, journal, and rollback policy.  In particular, the raw index
+//! facet persists the original bytes rather than reconstructing an Index, so
+//! intent-to-add, skip-worktree, assume-unchanged, and stat bits survive.
+
+use git_internal::{
+    hash::ObjectHash,
+    internal::object::types::ObjectType,
+};
+use serde_json::json;
+
+use super::{
+    FacetCapture, FacetCaptureCtx, FacetDiff, FacetError, FacetName, FacetRegistry,
+    FacetRestoreCtx, RestorePolicy,
+};
+use super::facet::StateFacet;
+use crate::{
+    internal::{
+        sequencer::{self, SequenceKind, SequenceState},
+        sparse::SparseViewStore,
+        worktree_scope::{RequestScope, WorktreeScope},
+    },
+    utils::{
+        atomic_write::write_atomic,
+        client_storage::ClientStorage,
+    },
+};
+
+const FACET_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone)]
+pub struct RawIndexFacet {
+    scope: RequestScope,
+    storage: ClientStorage,
+}
+
+impl RawIndexFacet {
+    pub fn new(scope: RequestScope, storage: ClientStorage) -> Self {
+        Self { scope, storage }
+    }
+}
+
+impl StateFacet for RawIndexFacet {
+    fn name(&self) -> FacetName { FacetName::from("index") }
+    fn schema_version(&self) -> u32 { FACET_SCHEMA_VERSION }
+    fn restore_policy(&self) -> RestorePolicy { RestorePolicy::AutoRestore }
+
+    fn capture(&self, _ctx: &FacetCaptureCtx) -> Result<FacetCapture, FacetError> {
+        let bytes = std::fs::read(self.scope.gitdir.join("index"))
+            .map_err(|error| FacetError::Capture(error.to_string()))?;
+        let oid = ObjectHash::from_type_and_data(ObjectType::Blob, &bytes);
+        self.storage
+            .put(&oid, &bytes, ObjectType::Blob)
+            .map_err(|error| FacetError::Capture(error.to_string()))?;
+        Ok(FacetCapture {
+            facet: self.name(),
+            schema_version: FACET_SCHEMA_VERSION,
+            payload_oid: Some(oid),
+            meta: json!({"byte_exact": true, "length": bytes.len()}),
+        })
+    }
+
+    fn validate(&self, capture: &FacetCapture) -> Result<(), FacetError> {
+        if capture.payload_oid.is_none() {
+            return Err(FacetError::Validation("index facet has no payload".to_string()));
+        }
+        Ok(())
+    }
+
+    fn restore(&self, capture: &FacetCapture, _ctx: &mut FacetRestoreCtx) -> Result<(), FacetError> {
+        let oid = capture.payload_oid.ok_or_else(|| FacetError::Restore("index payload is missing".to_string()))?;
+        let bytes = self.storage.get(&oid).map_err(|error| FacetError::Restore(error.to_string()))?;
+        write_atomic(&self.scope.gitdir.join("index"), &bytes, true)
+            .map_err(|error| FacetError::Restore(error.to_string()))
+    }
+
+    fn diff(&self, from: &FacetCapture, to: &FacetCapture) -> Result<FacetDiff, FacetError> {
+        Ok(FacetDiff { changes: json!({"from": from.payload_oid, "to": to.payload_oid}) })
+    }
+
+    fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> {
+        capture.payload_oid.into_iter().collect()
+    }
+}
+
+#[derive(Clone)]
+pub struct SequencerFacet {
+    scope: RequestScope,
+    storage: ClientStorage,
+}
+
+impl SequencerFacet {
+    pub fn new(scope: RequestScope, storage: ClientStorage) -> Self { Self { scope, storage } }
+}
+
+impl StateFacet for SequencerFacet {
+    fn name(&self) -> FacetName { FacetName::from("sequencer") }
+    fn schema_version(&self) -> u32 { FACET_SCHEMA_VERSION }
+    fn restore_policy(&self) -> RestorePolicy { RestorePolicy::AutoRestore }
+
+    fn capture(&self, _ctx: &FacetCaptureCtx) -> Result<FacetCapture, FacetError> {
+        let scope = self.scope.clone();
+        let state = run_async(async move { sequencer::load_for_scope(&scope.scope).await })
+            .map_err(FacetError::Capture)?
+            .map_err(FacetError::Capture)?;
+        let value = state.map(sequence_to_json).unwrap_or_else(|| json!({"present": false}));
+        let bytes = serde_json::to_vec(&value).map_err(|error| FacetError::Capture(error.to_string()))?;
+        let oid = ObjectHash::from_type_and_data(ObjectType::Blob, &bytes);
+        self.storage.put(&oid, &bytes, ObjectType::Blob).map_err(|error| FacetError::Capture(error.to_string()))?;
+        Ok(FacetCapture { facet: self.name(), schema_version: FACET_SCHEMA_VERSION, payload_oid: Some(oid), meta: json!({"present": value.get("present").is_none_or(|v| v != false)}) })
+    }
+
+    fn validate(&self, capture: &FacetCapture) -> Result<(), FacetError> {
+        capture.payload_oid.ok_or_else(|| FacetError::Validation("sequencer payload is missing".to_string())).map(|_| ())
+    }
+
+    fn restore(&self, capture: &FacetCapture, _ctx: &mut FacetRestoreCtx) -> Result<(), FacetError> {
+        let oid = capture.payload_oid.ok_or_else(|| FacetError::Restore("sequencer payload is missing".to_string()))?;
+        let bytes = self.storage.get(&oid).map_err(|error| FacetError::Restore(error.to_string()))?;
+        let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| FacetError::Restore(error.to_string()))?;
+        if value.get("present").and_then(serde_json::Value::as_bool) == Some(false) { return Ok(()); }
+        let state = sequence_from_json(&value).map_err(FacetError::Restore)?;
+        let scope = self.scope.clone();
+        run_async(async move {
+            let _pin = WorktreeScope::override_scope(scope.workdir.clone());
+            sequencer::save(&state).await
+        }).map_err(FacetError::Restore)?
+            .map_err(FacetError::Restore)?;
+        Ok(())
+    }
+
+    fn diff(&self, from: &FacetCapture, to: &FacetCapture) -> Result<FacetDiff, FacetError> {
+        Ok(FacetDiff { changes: json!({"from": from.payload_oid, "to": to.payload_oid}) })
+    }
+    fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> { capture.payload_oid.into_iter().collect() }
+}
+
+#[derive(Clone)]
+pub struct SparseFacet {
+    scope: RequestScope,
+    storage: ClientStorage,
+}
+
+impl SparseFacet {
+    pub fn new(scope: RequestScope, storage: ClientStorage) -> Self { Self { scope, storage } }
+}
+
+impl StateFacet for SparseFacet {
+    fn name(&self) -> FacetName { FacetName::from("sparse") }
+    fn schema_version(&self) -> u32 { FACET_SCHEMA_VERSION }
+    fn restore_policy(&self) -> RestorePolicy { RestorePolicy::Rebuild }
+
+    fn capture(&self, _ctx: &FacetCaptureCtx) -> Result<FacetCapture, FacetError> {
+        let scope = self.scope.clone();
+        let value = run_async(async move {
+            let patterns = SparseViewStore::list(&scope.scope).await?;
+            let enabled = SparseViewStore::is_enabled(&scope.scope).await;
+            Ok::<_, String>(json!({"enabled": enabled, "patterns": patterns}))
+        }).map_err(FacetError::Capture)?
+            .map_err(FacetError::Capture)?;
+        let bytes = serde_json::to_vec(&value).map_err(|error| FacetError::Capture(error.to_string()))?;
+        let oid = ObjectHash::from_type_and_data(ObjectType::Blob, &bytes);
+        self.storage.put(&oid, &bytes, ObjectType::Blob).map_err(|error| FacetError::Capture(error.to_string()))?;
+        Ok(FacetCapture { facet: self.name(), schema_version: FACET_SCHEMA_VERSION, payload_oid: Some(oid), meta: value })
+    }
+
+    fn validate(&self, capture: &FacetCapture) -> Result<(), FacetError> { capture.payload_oid.ok_or_else(|| FacetError::Validation("sparse payload is missing".to_string())).map(|_| ()) }
+    fn restore(&self, capture: &FacetCapture, _ctx: &mut FacetRestoreCtx) -> Result<(), FacetError> {
+        let oid = capture.payload_oid.ok_or_else(|| FacetError::Restore("sparse payload is missing".to_string()))?;
+        let value: serde_json::Value = serde_json::from_slice(&self.storage.get(&oid).map_err(|error| FacetError::Restore(error.to_string()))?).map_err(|error| FacetError::Restore(error.to_string()))?;
+        let patterns = value.get("patterns").and_then(serde_json::Value::as_array).ok_or_else(|| FacetError::Restore("sparse patterns are missing".to_string()))?.iter().filter_map(serde_json::Value::as_str).map(str::to_string).collect::<Vec<_>>();
+        let scope = self.scope.clone();
+        run_async(async move {
+            let _pin = WorktreeScope::override_scope(scope.workdir.clone());
+            SparseViewStore::replace(&scope.scope, &patterns).await
+        }).map_err(FacetError::Restore)?
+            .map_err(FacetError::Restore)?;
+        Ok(())
+    }
+    fn diff(&self, from: &FacetCapture, to: &FacetCapture) -> Result<FacetDiff, FacetError> { Ok(FacetDiff { changes: json!({"from": from.payload_oid, "to": to.payload_oid}) }) }
+    fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> { capture.payload_oid.into_iter().collect() }
+}
+
+/// Register exactly the three OL-07 mutable-state facets for a worktree.
+pub fn registry_for_scope(scope: RequestScope, storage: ClientStorage) -> Result<FacetRegistry, FacetError> {
+    let mut registry = FacetRegistry::new();
+    registry.register(Box::new(RawIndexFacet::new(scope.clone(), storage.clone())))?;
+    registry.register(Box::new(SequencerFacet::new(scope.clone(), storage.clone())))?;
+    registry.register(Box::new(SparseFacet::new(scope, storage)))?;
+    Ok(registry)
+}
+
+fn sequence_to_json(state: SequenceState) -> serde_json::Value {
+    json!({"present": true, "kind": state.kind.as_str(), "head_name": state.head_name, "head_orig": state.head_orig, "current_oid": state.current_oid, "todo": state.todo, "payload": state.payload})
+}
+
+fn sequence_from_json(value: &serde_json::Value) -> Result<SequenceState, String> {
+    let kind = match value.get("kind").and_then(serde_json::Value::as_str).ok_or("sequencer kind missing")? {
+        "merge" => SequenceKind::Merge,
+        "revert" => SequenceKind::Revert,
+        "cherry_pick" => SequenceKind::CherryPick,
+        "rebase" => SequenceKind::Rebase,
+        other => return Err(format!("unknown sequencer kind '{other}'")),
+    };
+    Ok(SequenceState {
+        kind,
+        head_name: string_field(value, "head_name")?,
+        head_orig: string_field(value, "head_orig")?,
+        current_oid: string_field(value, "current_oid")?,
+        todo: value.get("todo").and_then(serde_json::Value::as_array).ok_or("sequencer todo missing")?.iter().filter_map(serde_json::Value::as_str).map(str::to_string).collect(),
+        payload: string_field(value, "payload")?,
+    })
+}
+
+fn string_field(value: &serde_json::Value, key: &str) -> Result<String, String> { value.get(key).and_then(serde_json::Value::as_str).map(str::to_string).ok_or_else(|| format!("sequencer field '{key}' missing")) }
+
+fn run_async<T: Send + 'static>(future: impl std::future::Future<Output = T> + Send + 'static) -> Result<T, String> {
+    std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread().enable_all().build().map_err(|error| error.to_string()).and_then(|runtime| Ok(runtime.block_on(future)))
+    }).join().map_err(|_| "facet worker panicked".to_string())?
+}

--- a/src/internal/operation/facets.rs
+++ b/src/internal/operation/facets.rs
@@ -6,30 +6,22 @@
 //! facet persists the original bytes rather than reconstructing an Index, so
 //! intent-to-add, skip-worktree, assume-unchanged, and stat bits survive.
 
-use git_internal::{
-    hash::ObjectHash,
-    internal::object::types::ObjectType,
-};
+use std::io::Read;
+
+use git_internal::{hash::ObjectHash, internal::object::types::ObjectType};
 use serde_json::json;
 
 use super::{
     FacetCapture, FacetCaptureCtx, FacetDiff, FacetError, FacetName, FacetRegistry,
-    FacetRestoreCtx, RestorePolicy,
+    FacetRestoreCtx, RestorePolicy, facet::StateFacet,
 };
-use super::facet::StateFacet;
 use crate::{
-    internal::{
-        sequencer::{self, SequenceKind, SequenceState},
-        sparse::SparseViewStore,
-        worktree_scope::{RequestScope, WorktreeScope},
-    },
-    utils::{
-        atomic_write::write_atomic,
-        client_storage::ClientStorage,
-    },
+    internal::{sequencer, sparse, worktree_scope::RequestScope},
+    utils::{atomic_write::write_atomic, client_storage::ClientStorage},
 };
 
 const FACET_SCHEMA_VERSION: u32 = 1;
+const MAX_RAW_INDEX_BYTES: u64 = 512 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct RawIndexFacet {
@@ -44,13 +36,33 @@ impl RawIndexFacet {
 }
 
 impl StateFacet for RawIndexFacet {
-    fn name(&self) -> FacetName { FacetName::from("index") }
-    fn schema_version(&self) -> u32 { FACET_SCHEMA_VERSION }
-    fn restore_policy(&self) -> RestorePolicy { RestorePolicy::AutoRestore }
+    fn name(&self) -> FacetName {
+        FacetName::from("index")
+    }
+    fn schema_version(&self) -> u32 {
+        FACET_SCHEMA_VERSION
+    }
+    fn restore_policy(&self) -> RestorePolicy {
+        RestorePolicy::AutoRestore
+    }
 
     fn capture(&self, _ctx: &FacetCaptureCtx) -> Result<FacetCapture, FacetError> {
-        let bytes = std::fs::read(self.scope.gitdir.join("index"))
-            .map_err(|error| FacetError::Capture(error.to_string()))?;
+        let (present, bytes) = match std::fs::File::open(self.scope.gitdir.join("index")) {
+            Ok(file) => {
+                let mut bytes = Vec::new();
+                file.take(MAX_RAW_INDEX_BYTES.saturating_add(1))
+                    .read_to_end(&mut bytes)
+                    .map_err(|error| FacetError::Capture(error.to_string()))?;
+                if bytes.len() as u64 > MAX_RAW_INDEX_BYTES {
+                    return Err(FacetError::Capture(
+                        "raw index exceeds snapshot byte budget".to_string(),
+                    ));
+                }
+                (true, bytes)
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => (false, Vec::new()),
+            Err(error) => return Err(FacetError::Capture(error.to_string())),
+        };
         let oid = ObjectHash::from_type_and_data(ObjectType::Blob, &bytes);
         self.storage
             .put(&oid, &bytes, ObjectType::Blob)
@@ -59,26 +71,52 @@ impl StateFacet for RawIndexFacet {
             facet: self.name(),
             schema_version: FACET_SCHEMA_VERSION,
             payload_oid: Some(oid),
-            meta: json!({"byte_exact": true, "length": bytes.len()}),
+            meta: json!({"byte_exact": true, "length": bytes.len(), "present": present}),
         })
     }
 
     fn validate(&self, capture: &FacetCapture) -> Result<(), FacetError> {
         if capture.payload_oid.is_none() {
-            return Err(FacetError::Validation("index facet has no payload".to_string()));
+            return Err(FacetError::Validation(
+                "index facet has no payload".to_string(),
+            ));
         }
         Ok(())
     }
 
-    fn restore(&self, capture: &FacetCapture, _ctx: &mut FacetRestoreCtx) -> Result<(), FacetError> {
-        let oid = capture.payload_oid.ok_or_else(|| FacetError::Restore("index payload is missing".to_string()))?;
-        let bytes = self.storage.get(&oid).map_err(|error| FacetError::Restore(error.to_string()))?;
+    fn restore(
+        &self,
+        capture: &FacetCapture,
+        _ctx: &mut FacetRestoreCtx,
+    ) -> Result<(), FacetError> {
+        let oid = capture
+            .payload_oid
+            .ok_or_else(|| FacetError::Restore("index payload is missing".to_string()))?;
+        let bytes = self
+            .storage
+            .get(&oid)
+            .map_err(|error| FacetError::Restore(error.to_string()))?;
+        if capture
+            .meta
+            .get("present")
+            .and_then(serde_json::Value::as_bool)
+            == Some(false)
+        {
+            match std::fs::remove_file(self.scope.gitdir.join("index")) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(FacetError::Restore(error.to_string())),
+            }
+            return Ok(());
+        }
         write_atomic(&self.scope.gitdir.join("index"), &bytes, true)
             .map_err(|error| FacetError::Restore(error.to_string()))
     }
 
     fn diff(&self, from: &FacetCapture, to: &FacetCapture) -> Result<FacetDiff, FacetError> {
-        Ok(FacetDiff { changes: json!({"from": from.payload_oid, "to": to.payload_oid}) })
+        Ok(FacetDiff {
+            changes: json!({"from": from.payload_oid, "to": to.payload_oid}),
+        })
     }
 
     fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> {
@@ -93,49 +131,93 @@ pub struct SequencerFacet {
 }
 
 impl SequencerFacet {
-    pub fn new(scope: RequestScope, storage: ClientStorage) -> Self { Self { scope, storage } }
+    pub fn new(scope: RequestScope, storage: ClientStorage) -> Self {
+        Self { scope, storage }
+    }
 }
 
 impl StateFacet for SequencerFacet {
-    fn name(&self) -> FacetName { FacetName::from("sequencer") }
-    fn schema_version(&self) -> u32 { FACET_SCHEMA_VERSION }
-    fn restore_policy(&self) -> RestorePolicy { RestorePolicy::AutoRestore }
+    fn name(&self) -> FacetName {
+        FacetName::from("sequencer")
+    }
+    fn schema_version(&self) -> u32 {
+        FACET_SCHEMA_VERSION
+    }
+    fn restore_policy(&self) -> RestorePolicy {
+        RestorePolicy::AutoRestore
+    }
 
     fn capture(&self, _ctx: &FacetCaptureCtx) -> Result<FacetCapture, FacetError> {
         let scope = self.scope.clone();
-        let state = run_async(async move { sequencer::load_for_scope(&scope.scope).await })
+        let storage = scope.storage.clone();
+        let state =
+            run_async(
+                async move { sequencer::load_snapshot_for_storage(&storage, &scope.scope).await },
+            )
             .map_err(FacetError::Capture)?
             .map_err(FacetError::Capture)?;
-        let value = state.map(sequence_to_json).unwrap_or_else(|| json!({"present": false}));
-        let bytes = serde_json::to_vec(&value).map_err(|error| FacetError::Capture(error.to_string()))?;
+        let value = state.unwrap_or_else(|| json!({"present": false}));
+        let bytes =
+            serde_json::to_vec(&value).map_err(|error| FacetError::Capture(error.to_string()))?;
         let oid = ObjectHash::from_type_and_data(ObjectType::Blob, &bytes);
-        self.storage.put(&oid, &bytes, ObjectType::Blob).map_err(|error| FacetError::Capture(error.to_string()))?;
-        Ok(FacetCapture { facet: self.name(), schema_version: FACET_SCHEMA_VERSION, payload_oid: Some(oid), meta: json!({"present": value.get("present").is_none_or(|v| v != false)}) })
+        self.storage
+            .put(&oid, &bytes, ObjectType::Blob)
+            .map_err(|error| FacetError::Capture(error.to_string()))?;
+        Ok(FacetCapture {
+            facet: self.name(),
+            schema_version: FACET_SCHEMA_VERSION,
+            payload_oid: Some(oid),
+            meta: json!({"present": value.get("present").is_none_or(|v| v != false)}),
+        })
     }
 
     fn validate(&self, capture: &FacetCapture) -> Result<(), FacetError> {
-        capture.payload_oid.ok_or_else(|| FacetError::Validation("sequencer payload is missing".to_string())).map(|_| ())
+        capture
+            .payload_oid
+            .ok_or_else(|| FacetError::Validation("sequencer payload is missing".to_string()))
+            .map(|_| ())
     }
 
-    fn restore(&self, capture: &FacetCapture, _ctx: &mut FacetRestoreCtx) -> Result<(), FacetError> {
-        let oid = capture.payload_oid.ok_or_else(|| FacetError::Restore("sequencer payload is missing".to_string()))?;
-        let bytes = self.storage.get(&oid).map_err(|error| FacetError::Restore(error.to_string()))?;
-        let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| FacetError::Restore(error.to_string()))?;
-        if value.get("present").and_then(serde_json::Value::as_bool) == Some(false) { return Ok(()); }
-        let state = sequence_from_json(&value).map_err(FacetError::Restore)?;
+    fn restore(
+        &self,
+        capture: &FacetCapture,
+        _ctx: &mut FacetRestoreCtx,
+    ) -> Result<(), FacetError> {
+        let oid = capture
+            .payload_oid
+            .ok_or_else(|| FacetError::Restore("sequencer payload is missing".to_string()))?;
+        let bytes = self
+            .storage
+            .get(&oid)
+            .map_err(|error| FacetError::Restore(error.to_string()))?;
+        let value: serde_json::Value = serde_json::from_slice(&bytes)
+            .map_err(|error| FacetError::Restore(error.to_string()))?;
+        if value.get("present").and_then(serde_json::Value::as_bool) == Some(false) {
+            let scope = self.scope.clone();
+            run_async(async move {
+                sequencer::clear_snapshot_for_storage(&scope.storage, &scope.scope).await
+            })
+            .map_err(FacetError::Restore)?
+            .map_err(FacetError::Restore)?;
+            return Ok(());
+        }
         let scope = self.scope.clone();
         run_async(async move {
-            let _pin = WorktreeScope::override_scope(scope.workdir.clone());
-            sequencer::save(&state).await
-        }).map_err(FacetError::Restore)?
-            .map_err(FacetError::Restore)?;
+            sequencer::restore_snapshot_for_storage(&scope.storage, &scope.scope, &value).await
+        })
+        .map_err(FacetError::Restore)?
+        .map_err(FacetError::Restore)?;
         Ok(())
     }
 
     fn diff(&self, from: &FacetCapture, to: &FacetCapture) -> Result<FacetDiff, FacetError> {
-        Ok(FacetDiff { changes: json!({"from": from.payload_oid, "to": to.payload_oid}) })
+        Ok(FacetDiff {
+            changes: json!({"from": from.payload_oid, "to": to.payload_oid}),
+        })
     }
-    fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> { capture.payload_oid.into_iter().collect() }
+    fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> {
+        capture.payload_oid.into_iter().collect()
+    }
 }
 
 #[derive(Clone)]
@@ -145,84 +227,121 @@ pub struct SparseFacet {
 }
 
 impl SparseFacet {
-    pub fn new(scope: RequestScope, storage: ClientStorage) -> Self { Self { scope, storage } }
+    pub fn new(scope: RequestScope, storage: ClientStorage) -> Self {
+        Self { scope, storage }
+    }
 }
 
 impl StateFacet for SparseFacet {
-    fn name(&self) -> FacetName { FacetName::from("sparse") }
-    fn schema_version(&self) -> u32 { FACET_SCHEMA_VERSION }
-    fn restore_policy(&self) -> RestorePolicy { RestorePolicy::Rebuild }
+    fn name(&self) -> FacetName {
+        FacetName::from("sparse")
+    }
+    fn schema_version(&self) -> u32 {
+        FACET_SCHEMA_VERSION
+    }
+    fn restore_policy(&self) -> RestorePolicy {
+        RestorePolicy::Rebuild
+    }
 
     fn capture(&self, _ctx: &FacetCaptureCtx) -> Result<FacetCapture, FacetError> {
         let scope = self.scope.clone();
+        let storage = scope.storage.clone();
         let value = run_async(async move {
-            let patterns = SparseViewStore::list(&scope.scope).await?;
-            let enabled = SparseViewStore::is_enabled(&scope.scope).await;
+            let (patterns, enabled) = sparse::snapshot_for_storage(&storage, &scope.scope).await?;
             Ok::<_, String>(json!({"enabled": enabled, "patterns": patterns}))
-        }).map_err(FacetError::Capture)?
-            .map_err(FacetError::Capture)?;
-        let bytes = serde_json::to_vec(&value).map_err(|error| FacetError::Capture(error.to_string()))?;
+        })
+        .map_err(FacetError::Capture)?
+        .map_err(FacetError::Capture)?;
+        let bytes =
+            serde_json::to_vec(&value).map_err(|error| FacetError::Capture(error.to_string()))?;
         let oid = ObjectHash::from_type_and_data(ObjectType::Blob, &bytes);
-        self.storage.put(&oid, &bytes, ObjectType::Blob).map_err(|error| FacetError::Capture(error.to_string()))?;
-        Ok(FacetCapture { facet: self.name(), schema_version: FACET_SCHEMA_VERSION, payload_oid: Some(oid), meta: value })
+        self.storage
+            .put(&oid, &bytes, ObjectType::Blob)
+            .map_err(|error| FacetError::Capture(error.to_string()))?;
+        Ok(FacetCapture {
+            facet: self.name(),
+            schema_version: FACET_SCHEMA_VERSION,
+            payload_oid: Some(oid),
+            meta: value,
+        })
     }
 
-    fn validate(&self, capture: &FacetCapture) -> Result<(), FacetError> { capture.payload_oid.ok_or_else(|| FacetError::Validation("sparse payload is missing".to_string())).map(|_| ()) }
-    fn restore(&self, capture: &FacetCapture, _ctx: &mut FacetRestoreCtx) -> Result<(), FacetError> {
-        let oid = capture.payload_oid.ok_or_else(|| FacetError::Restore("sparse payload is missing".to_string()))?;
-        let value: serde_json::Value = serde_json::from_slice(&self.storage.get(&oid).map_err(|error| FacetError::Restore(error.to_string()))?).map_err(|error| FacetError::Restore(error.to_string()))?;
-        let patterns = value.get("patterns").and_then(serde_json::Value::as_array).ok_or_else(|| FacetError::Restore("sparse patterns are missing".to_string()))?.iter().filter_map(serde_json::Value::as_str).map(str::to_string).collect::<Vec<_>>();
+    fn validate(&self, capture: &FacetCapture) -> Result<(), FacetError> {
+        capture
+            .payload_oid
+            .ok_or_else(|| FacetError::Validation("sparse payload is missing".to_string()))
+            .map(|_| ())
+    }
+    fn restore(
+        &self,
+        capture: &FacetCapture,
+        _ctx: &mut FacetRestoreCtx,
+    ) -> Result<(), FacetError> {
+        let oid = capture
+            .payload_oid
+            .ok_or_else(|| FacetError::Restore("sparse payload is missing".to_string()))?;
+        let value: serde_json::Value = serde_json::from_slice(
+            &self
+                .storage
+                .get(&oid)
+                .map_err(|error| FacetError::Restore(error.to_string()))?,
+        )
+        .map_err(|error| FacetError::Restore(error.to_string()))?;
+        let patterns = value
+            .get("patterns")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| FacetError::Restore("sparse patterns are missing".to_string()))?
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::to_string)
+            .collect::<Vec<_>>();
         let scope = self.scope.clone();
         run_async(async move {
-            let _pin = WorktreeScope::override_scope(scope.workdir.clone());
-            SparseViewStore::replace(&scope.scope, &patterns).await?;
-            if value.get("enabled").and_then(serde_json::Value::as_bool) == Some(false) {
-                SparseViewStore::disable(&scope.scope).await?;
-            }
-            Ok::<_, String>(())
-        }).map_err(FacetError::Restore)?
-            .map_err(FacetError::Restore)?;
+            let enabled = value
+                .get("enabled")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            sparse::restore_for_storage(&scope.storage, &scope.scope, &patterns, enabled).await
+        })
+        .map_err(FacetError::Restore)?
+        .map_err(FacetError::Restore)?;
         Ok(())
     }
-    fn diff(&self, from: &FacetCapture, to: &FacetCapture) -> Result<FacetDiff, FacetError> { Ok(FacetDiff { changes: json!({"from": from.payload_oid, "to": to.payload_oid}) }) }
-    fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> { capture.payload_oid.into_iter().collect() }
+    fn diff(&self, from: &FacetCapture, to: &FacetCapture) -> Result<FacetDiff, FacetError> {
+        Ok(FacetDiff {
+            changes: json!({"from": from.payload_oid, "to": to.payload_oid}),
+        })
+    }
+    fn roots(&self, capture: &FacetCapture) -> Vec<ObjectHash> {
+        capture.payload_oid.into_iter().collect()
+    }
 }
 
 /// Register exactly the three OL-07 mutable-state facets for a worktree.
-pub fn registry_for_scope(scope: RequestScope, storage: ClientStorage) -> Result<FacetRegistry, FacetError> {
+pub fn registry_for_scope(
+    scope: RequestScope,
+    storage: ClientStorage,
+) -> Result<FacetRegistry, FacetError> {
     let mut registry = FacetRegistry::new();
     registry.register(Box::new(RawIndexFacet::new(scope.clone(), storage.clone())))?;
-    registry.register(Box::new(SequencerFacet::new(scope.clone(), storage.clone())))?;
+    registry.register(Box::new(SequencerFacet::new(
+        scope.clone(),
+        storage.clone(),
+    )))?;
     registry.register(Box::new(SparseFacet::new(scope, storage)))?;
     Ok(registry)
 }
 
-fn sequence_to_json(state: SequenceState) -> serde_json::Value {
-    json!({"present": true, "kind": state.kind.as_str(), "head_name": state.head_name, "head_orig": state.head_orig, "current_oid": state.current_oid, "todo": state.todo, "payload": state.payload})
-}
-
-fn sequence_from_json(value: &serde_json::Value) -> Result<SequenceState, String> {
-    let kind = match value.get("kind").and_then(serde_json::Value::as_str).ok_or("sequencer kind missing")? {
-        "merge" => SequenceKind::Merge,
-        "revert" => SequenceKind::Revert,
-        "cherry_pick" => SequenceKind::CherryPick,
-        "rebase" => SequenceKind::Rebase,
-        other => return Err(format!("unknown sequencer kind '{other}'")),
-    };
-    Ok(SequenceState {
-        kind,
-        head_name: string_field(value, "head_name")?,
-        head_orig: string_field(value, "head_orig")?,
-        current_oid: string_field(value, "current_oid")?,
-        todo: value.get("todo").and_then(serde_json::Value::as_array).ok_or("sequencer todo missing")?.iter().filter_map(serde_json::Value::as_str).map(str::to_string).collect(),
-        payload: string_field(value, "payload")?,
-    })
-}
-
-fn string_field(value: &serde_json::Value, key: &str) -> Result<String, String> { value.get(key).and_then(serde_json::Value::as_str).map(str::to_string).ok_or_else(|| format!("sequencer field '{key}' missing")) }
-
-fn run_async<T: Send + 'static>(future: impl std::future::Future<Output = T> + Send + 'static) -> Result<T, String> {
+fn run_async<T: Send + 'static>(
+    future: impl std::future::Future<Output = T> + Send + 'static,
+) -> Result<T, String> {
     std::thread::spawn(move || {
-        tokio::runtime::Builder::new_current_thread().enable_all().build().map_err(|error| error.to_string()).and_then(|runtime| Ok(runtime.block_on(future)))
-    }).join().map_err(|_| "facet worker panicked".to_string())?
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| error.to_string())
+            .map(|runtime| runtime.block_on(future))
+    })
+    .join()
+    .map_err(|_| "facet worker panicked".to_string())?
 }

--- a/src/internal/operation/middleware.rs
+++ b/src/internal/operation/middleware.rs
@@ -6,12 +6,35 @@
 //! time census for every concrete command variant.  Unknown names are a hard
 //! error: an unclassified mutation must never silently run outside the log.
 
-use std::{future::Future, pin::Pin};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+use std::{
+    fs::{File, OpenOptions},
+    future::Future,
+    io::Write,
+    pin::Pin,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
+use git_internal::{hash::ObjectHash, internal::object::types::ObjectType};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use serde_json::json;
 use thiserror::Error;
 use uuid::Uuid;
 
-use super::{OperationMetaV2, PinnedRequestScope};
+use super::{
+    Completeness, JournalEntry, JournalPhase, OperationKind, OperationMetaV2, OperationStatusV2,
+    OperationStoreV2, OperationV2, PinnedRequestScope, RepoViewV2, SnapshotError, Staleness,
+    WorkspaceSnapshotter, WorkspaceStatePointer,
+};
+use crate::{
+    internal::{db::get_db_conn_instance_for_path, workspace::RepoIdentity},
+    utils::{
+        client_storage::ClientStorage,
+        error::{CliError, StableErrorCode},
+        util::DATABASE,
+    },
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MutationClass {
@@ -41,8 +64,8 @@ pub fn classify_command(name: &str) -> Result<MutationClass, ClassificationError
         }
         "add" | "rm" | "mv" | "restore" | "clean" | "checkout" | "switch" | "apply"
         | "read-tree" | "update-index" | "hydrate" => MutationClass::WorkspaceMutation,
-        "branch" | "tag" | "commit" | "reset" | "fetch" | "pull" | "config-set"
-        | "metadata" | "file" => MutationClass::RepoMutation,
+        "branch" | "tag" | "commit" | "reset" | "fetch" | "pull" | "config-set" | "metadata"
+        | "file" => MutationClass::RepoMutation,
         "merge" | "rebase" | "cherry-pick" | "revert" | "am" | "bisect" => {
             MutationClass::SequencerMutation
         }
@@ -50,9 +73,7 @@ pub fn classify_command(name: &str) -> Result<MutationClass, ClassificationError
             MutationClass::LibraStateMutation
         }
         "shell" | "exec" | "external-git" | "hook" => MutationClass::ExternalOrUnknown,
-        "internal-worker" | "recovery-worker" | "status-io-worker" => {
-            MutationClass::InternalWorker
-        }
+        "internal-worker" | "recovery-worker" | "status-io-worker" => MutationClass::InternalWorker,
         _ => return Err(ClassificationError::Unknown(name)),
     };
     Ok(class)
@@ -66,6 +87,14 @@ pub enum OperationError {
     ExternalUnverified,
     #[error("operation mutation failed: {0}")]
     Mutation(String),
+    #[error("operation storage failed: {0}")]
+    Storage(String),
+    #[error("workspace operation pointer is stale: {0}")]
+    Stale(String),
+    #[error("operation publication compare-and-swap failed: {0}")]
+    Cas(String),
+    #[error(transparent)]
+    Cli(#[from] CliError),
 }
 
 /// Mutable context passed to the business closure.  It carries the stable
@@ -74,16 +103,12 @@ pub enum OperationError {
 pub struct OperationTxn {
     pub op_id: String,
     pub class: MutationClass,
-    external_verified: bool,
+    post_snapshot_complete: bool,
 }
 
 impl OperationTxn {
-    pub fn mark_external_verified(&mut self) {
-        self.external_verified = true;
-    }
-
-    pub fn external_verified(&self) -> bool {
-        self.external_verified
+    fn observe_post_snapshot(&mut self, complete: bool) {
+        self.post_snapshot_complete = complete;
     }
 }
 
@@ -96,15 +121,15 @@ pub struct OperationResult<T> {
 
 /// Execute a closure at the unified mutation boundary.
 ///
-/// The storage-backed publication seam is deliberately kept behind the same
-/// context and classification contract; callers that own the repository
-/// transaction publish the immutable pre/post manifests and CAS head in the
-/// closure's surrounding store transaction.  This function still enforces
-/// the two non-negotiable gates here: read-only/internal work does not create
-/// an operation, and unverifiable external work fails closed.
+/// Repository-backed scopes execute the complete v2 pipeline: scope lease,
+/// pointer/head freshness check, pre-snapshot, journal reservation, business
+/// mutation, post-snapshot, operation persistence, head CAS, and pointer
+/// advancement.  The small in-memory fallback exists only for callers that
+/// deliberately operate outside a repository (and keeps the classifier useful
+/// to unit tests); a real pinned repository never takes that path.
 pub async fn run_with_operation<T, F, Fut>(
-    _scope: &PinnedRequestScope,
-    _meta: OperationMetaV2,
+    scope: &PinnedRequestScope,
+    meta: OperationMetaV2,
     class: MutationClass,
     f: F,
 ) -> Result<OperationResult<T>, OperationError>
@@ -112,16 +137,35 @@ where
     F: FnOnce(&mut OperationTxn) -> Fut,
     Fut: Future<Output = Result<T, OperationError>>,
 {
-    let should_record = !matches!(class, MutationClass::ReadOnly | MutationClass::InternalWorker);
+    if repository_scope_is_ready(scope) {
+        return run_with_persistent_operation(scope, meta, class, f).await;
+    }
+    if class == MutationClass::ExternalOrUnknown {
+        // Outside a pinned repository there is no bounded before/after
+        // snapshot, so an external mutation must not be executed at all.
+        return Err(OperationError::ExternalUnverified);
+    }
+    run_ephemeral_operation(class, f).await
+}
+
+async fn run_ephemeral_operation<T, F, Fut>(
+    class: MutationClass,
+    f: F,
+) -> Result<OperationResult<T>, OperationError>
+where
+    F: FnOnce(&mut OperationTxn) -> Fut,
+    Fut: Future<Output = Result<T, OperationError>>,
+{
+    let should_record = !matches!(
+        class,
+        MutationClass::ReadOnly | MutationClass::InternalWorker
+    );
     let mut txn = OperationTxn {
         op_id: Uuid::now_v7().to_string(),
         class,
-        external_verified: false,
+        post_snapshot_complete: false,
     };
     let value = f(&mut txn).await?;
-    if matches!(class, MutationClass::ExternalOrUnknown) && !txn.external_verified {
-        return Err(OperationError::ExternalUnverified);
-    }
     Ok(OperationResult {
         value,
         operation_id: should_record.then_some(txn.op_id),
@@ -129,8 +173,579 @@ where
     })
 }
 
+fn repository_scope_is_ready(scope: &PinnedRequestScope) -> bool {
+    // A pinned gitdir is enough to identify a repository-backed mutation.  Do
+    // not silently fall back to the ephemeral path when the database is
+    // missing or damaged: that would let a real repository mutation bypass
+    // the v2 journal and snapshot boundary.
+    scope.gitdir.is_dir()
+}
+
+struct ScopeLease {
+    #[cfg(unix)]
+    file: File,
+    #[cfg(not(unix))]
+    _key: String,
+}
+
+impl ScopeLease {
+    async fn acquire(scope: &PinnedRequestScope, repo_id: &str) -> Result<Self, OperationError> {
+        let key = format!("{repo_id}:{}", scope.scope.storage_key());
+        #[cfg(unix)]
+        {
+            let path = scope.gitdir.join("info").join("operation-v2.lock");
+            tokio::task::spawn_blocking(move || Self::acquire_blocking(path, key))
+                .await
+                .map_err(|error| OperationError::Storage(error.to_string()))?
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(Self { _key: key })
+        }
+    }
+
+    #[cfg(unix)]
+    fn acquire_blocking(path: std::path::PathBuf, key: String) -> Result<Self, OperationError> {
+        std::fs::create_dir_all(path.parent().expect("lock has parent"))
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if result != 0 {
+            return Err(OperationError::Storage(format!(
+                "operation scope lease is already held for {key}"
+            )));
+        }
+        let _ = (&file).write_all(format!("pid={}\n", std::process::id()).as_bytes());
+        Ok(Self { file })
+    }
+}
+
+impl Drop for ScopeLease {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        unsafe {
+            let _ = libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+async fn run_with_persistent_operation<T, F, Fut>(
+    scope: &PinnedRequestScope,
+    meta: OperationMetaV2,
+    class: MutationClass,
+    f: F,
+) -> Result<OperationResult<T>, OperationError>
+where
+    F: FnOnce(&mut OperationTxn) -> Fut,
+    Fut: Future<Output = Result<T, OperationError>>,
+{
+    if matches!(
+        class,
+        MutationClass::ReadOnly | MutationClass::InternalWorker
+    ) {
+        return run_ephemeral_operation(class, f).await;
+    }
+
+    // Agent gateways resolve a RequestScope without going through the CLI
+    // dispatcher, so no process-global request pin exists yet.  Install the
+    // already-resolved scope for the complete transaction; facets and legacy
+    // helpers must not re-resolve the ambient CWD and accidentally inspect a
+    // different repository.
+    let _scope_guard =
+        crate::internal::worktree_scope::WorktreeScope::pin_request_scope(scope.workdir.clone());
+
+    let db_path = scope.storage.join(DATABASE);
+    let db = get_db_conn_instance_for_path(&db_path)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    let identity = RepoIdentity::resolve(&db)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    let repo_id = identity.as_str().to_string();
+    let _lease = ScopeLease::acquire(scope, &repo_id).await?;
+    let storage = ClientStorage::init_local(scope.storage.join("objects"));
+    let store = OperationStoreV2::new_for_repo(&repo_id, db.clone(), storage.clone());
+    let scope_key = scope.scope.storage_key().to_string();
+    let mut heads = store
+        .read_heads_view(&repo_id, &scope_key)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    let mut expected_generation = store
+        .read_head_generation(&repo_id, &scope_key)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    let pointer = match WorkspaceStatePointer::load(scope).await {
+        Ok(pointer) => pointer,
+        Err(super::PointerError::Missing(_)) => bootstrap_pointer(&heads)?,
+        Err(error) => return Err(OperationError::Stale(error.to_string())),
+    };
+    if !heads.head_ids().is_empty() {
+        match pointer.staleness(&heads) {
+            Staleness::Fresh => {}
+            state => {
+                return Err(OperationError::Stale(format!(
+                    "working-copy pointer is {state:?} against current heads"
+                )));
+            }
+        }
+    }
+
+    let mut pre_snapshotter = WorkspaceSnapshotter::new(scope.clone(), pointer.clone());
+    let pre = pre_snapshotter
+        .capture()
+        .await
+        .map_err(snapshot_error_to_operation)?;
+    if class == MutationClass::ExternalOrUnknown && pre.snapshot.completeness != Completeness::Full
+    {
+        return Err(OperationError::Storage(
+            "pre-mutation external snapshot is partial; refusing to mutate without a coherent baseline"
+                .to_string(),
+        ));
+    }
+    let pre_refs = capture_reference_state(&db).await?;
+
+    // The pointer records the last captured workspace, so a changed disk
+    // state on entry is an external mutation that must become its own DAG
+    // operation before the requested command can run.
+    let previous_content_oid = pointer
+        .last_content_oid
+        .unwrap_or(pointer.last_snapshot_oid);
+    if pointer.last_op_id != "bootstrap" && previous_content_oid != pre.content_oid {
+        let external_id = Uuid::now_v7().to_string();
+        let external_view_oid = write_view(
+            &store,
+            &repo_id,
+            &pre.snapshot,
+            pre.snapshot_oid,
+            &pre_refs,
+            &heads.head_ids(),
+        )?;
+        let external = OperationV2 {
+            op_id: external_id.clone(),
+            parent_op_ids: heads.head_ids(),
+            pre_view_oid: external_view_oid,
+            post_view_oid: external_view_oid,
+            kind: OperationKind::ExternalSnapshot,
+            status: OperationStatusV2::Running,
+            metadata: OperationMetaV2 {
+                command_name: Some("external.snapshot".to_string()),
+                description: Some("External workspace change detected".to_string()),
+                ..Default::default()
+            },
+            restores_op_id: None,
+            reverts_op_id: None,
+            predecessor_map_oid: None,
+        };
+        store
+            .write_operation(&external)
+            .await
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        append_journal(
+            &store,
+            &external_id,
+            JournalPhase::Publish,
+            Some(external_view_oid),
+            Some(external_view_oid),
+            &format!("pid-{}", std::process::id()),
+            now_millis(),
+        )
+        .await?;
+        let generation = match store
+            .cas_update_op_heads_at_generation(
+                &repo_id,
+                &scope_key,
+                expected_generation,
+                &external.parent_op_ids,
+                std::slice::from_ref(&external_id),
+            )
+            .await
+        {
+            Ok(generation) => generation,
+            Err(error) => {
+                let _ = store
+                    .update_operation_status(&external_id, OperationStatusV2::Failed)
+                    .await;
+                return Err(OperationError::Cas(error.to_string()));
+            }
+        };
+        let mut external_pointer =
+            WorkspaceStatePointer::new(external_id.clone(), pre.snapshot_oid, generation);
+        external_pointer.last_content_oid = Some(pre.content_oid);
+        external_pointer
+            .save(scope)
+            .await
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        store
+            .update_operation_status(&external_id, OperationStatusV2::Success)
+            .await
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        heads = store
+            .read_heads_view(&repo_id, &scope_key)
+            .await
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        expected_generation = generation;
+    }
+    let pre_view_oid = write_view(
+        &store,
+        &repo_id,
+        &pre.snapshot,
+        pre.snapshot_oid,
+        &pre_refs,
+        &heads.head_ids(),
+    )?;
+    let operation_id = Uuid::now_v7().to_string();
+    let owner = format!("pid-{}", std::process::id());
+    let now = now_millis();
+    let operation = OperationV2 {
+        op_id: operation_id.clone(),
+        parent_op_ids: heads.head_ids(),
+        pre_view_oid,
+        post_view_oid: pre_view_oid,
+        kind: if class == MutationClass::ExternalOrUnknown {
+            OperationKind::ExternalSnapshot
+        } else {
+            OperationKind::Command
+        },
+        status: OperationStatusV2::Running,
+        metadata: meta.clone(),
+        restores_op_id: None,
+        reverts_op_id: None,
+        predecessor_map_oid: None,
+    };
+    store
+        .write_operation(&operation)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    append_journal(
+        &store,
+        &operation_id,
+        JournalPhase::Reserved,
+        Some(pre_view_oid),
+        None,
+        &owner,
+        now,
+    )
+    .await?;
+    append_journal(
+        &store,
+        &operation_id,
+        JournalPhase::PreView,
+        Some(pre_view_oid),
+        None,
+        &owner,
+        now,
+    )
+    .await?;
+    let mut txn = OperationTxn {
+        op_id: operation_id.clone(),
+        class,
+        post_snapshot_complete: false,
+    };
+    append_journal(
+        &store,
+        &operation_id,
+        JournalPhase::Mutation,
+        Some(pre_view_oid),
+        None,
+        &owner,
+        now_millis(),
+    )
+    .await?;
+    let value = match f(&mut txn).await {
+        Ok(value) => value,
+        Err(error) => {
+            persist_failed_operation(
+                &store,
+                &operation_id,
+                &meta,
+                &heads.head_ids(),
+                pre_view_oid,
+                &owner,
+            )
+            .await?;
+            return Err(error);
+        }
+    };
+
+    let mut post_snapshotter = WorkspaceSnapshotter::new(scope.clone(), pointer.clone());
+    let post = match post_snapshotter.capture().await {
+        Ok(post) => post,
+        Err(error) => {
+            persist_failed_operation(
+                &store,
+                &operation_id,
+                &meta,
+                &heads.head_ids(),
+                pre_view_oid,
+                &owner,
+            )
+            .await?;
+            return Err(OperationError::Storage(error.to_string()));
+        }
+    };
+    txn.observe_post_snapshot(post.snapshot.completeness == Completeness::Full);
+    if class == MutationClass::ExternalOrUnknown && !txn.post_snapshot_complete {
+        persist_failed_operation(
+            &store,
+            &operation_id,
+            &meta,
+            &heads.head_ids(),
+            pre_view_oid,
+            &owner,
+        )
+        .await?;
+        return Err(OperationError::ExternalUnverified);
+    }
+    let post_refs = capture_reference_state(&db).await?;
+    let full_view_is_unchanged = pre.snapshot.completeness == Completeness::Full
+        && post.snapshot.completeness == Completeness::Full
+        && pre.content_oid == post.content_oid
+        && pre_refs == post_refs;
+    if full_view_is_unchanged
+        && matches!(
+            class,
+            MutationClass::WorkspaceMutation | MutationClass::ExternalOrUnknown
+        )
+    {
+        store
+            .delete_operation(&operation_id)
+            .await
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        store
+            .delete_journal(&operation_id)
+            .await
+            .map_err(|error| OperationError::Storage(error.to_string()))?;
+        return Ok(OperationResult {
+            value,
+            operation_id: None,
+            recorded: false,
+        });
+    }
+    let post_view_oid = write_view(
+        &store,
+        &repo_id,
+        &post.snapshot,
+        post.snapshot_oid,
+        &post_refs,
+        &heads.head_ids(),
+    )?;
+    append_journal(
+        &store,
+        &operation_id,
+        JournalPhase::PostView,
+        Some(pre_view_oid),
+        Some(post_view_oid),
+        &owner,
+        now_millis(),
+    )
+    .await?;
+    store
+        .update_operation_post_view(&operation_id, &post_view_oid)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    append_journal(
+        &store,
+        &operation_id,
+        JournalPhase::Publish,
+        Some(pre_view_oid),
+        Some(post_view_oid),
+        &owner,
+        now_millis(),
+    )
+    .await?;
+    let generation = match store
+        .cas_update_op_heads_at_generation(
+            &repo_id,
+            &scope_key,
+            expected_generation,
+            &operation.parent_op_ids,
+            std::slice::from_ref(&operation_id),
+        )
+        .await
+    {
+        Ok(generation) => generation,
+        Err(error) => {
+            let _ = store
+                .update_operation_status(&operation_id, OperationStatusV2::Failed)
+                .await;
+            return Err(OperationError::Cas(error.to_string()));
+        }
+    };
+    let mut operation_pointer =
+        WorkspaceStatePointer::new(operation_id.clone(), post.snapshot_oid, generation);
+    operation_pointer.last_content_oid = Some(post.content_oid);
+    operation_pointer
+        .save(scope)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    store
+        .update_operation_status(&operation_id, OperationStatusV2::Success)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    Ok(OperationResult {
+        value,
+        operation_id: Some(operation_id),
+        recorded: true,
+    })
+}
+
+/// A newly attached/re-created worktree has a fresh gitdir and therefore no
+/// pointer file, even though the repository may already have published heads.
+/// Treat that identity as a new incarnation rooted at the current head. Its
+/// zero content OID deliberately forces the next boundary to capture the
+/// current worktree as an external snapshot before publishing the mutation.
+fn bootstrap_pointer(heads: &super::OpHeadsView) -> Result<WorkspaceStatePointer, OperationError> {
+    let (last_op_id, generation) = heads
+        .heads
+        .iter()
+        .max_by_key(|(_, generation)| *generation)
+        .map(|(op_id, generation)| (op_id.clone(), *generation))
+        .unwrap_or_else(|| ("bootstrap".to_string(), 0));
+    let zero_oid = ObjectHash::from_bytes(&vec![0; git_internal::hash::get_hash_kind().size()])
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    Ok(WorkspaceStatePointer::new(last_op_id, zero_oid, generation))
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+fn snapshot_error_to_operation(error: SnapshotError) -> OperationError {
+    let detail = error.to_string();
+    let lower = detail.to_ascii_lowercase();
+    if lower.contains("failed to load tree object") || lower.contains("existing tree object") {
+        return OperationError::Cli(
+            CliError::fatal(format!("failed to load tree: {detail}"))
+                .with_stable_code(StableErrorCode::RepoCorrupt),
+        );
+    }
+    if lower.contains("failed to register its cloud object-index repair marker")
+        || lower.contains("failed to store object")
+    {
+        return OperationError::Cli(
+            CliError::fatal(format!("failed to store object: {detail}"))
+                .with_stable_code(StableErrorCode::IoWriteFailed),
+        );
+    }
+    if lower.contains("index") {
+        return OperationError::Cli(
+            CliError::fatal(format!("unable to read index: {detail}"))
+                .with_stable_code(StableErrorCode::RepoCorrupt),
+        );
+    }
+    OperationError::Storage(detail)
+}
+
+fn write_view(
+    store: &OperationStoreV2,
+    repo_id: &str,
+    snapshot: &super::WorkspaceSnapshotV2,
+    snapshot_oid: ObjectHash,
+    refs: &serde_json::Value,
+    heads: &[String],
+) -> Result<ObjectHash, OperationError> {
+    let refs_bytes = serde_json::to_vec(&json!({"heads": heads, "references": refs}))
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    let refs_oid = ObjectHash::from_type_and_data(ObjectType::Blob, &refs_bytes);
+    store
+        .write_blob(&refs_oid, &refs_bytes, ObjectType::Blob)
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    let workspace_id = snapshot.workspace_id.clone();
+    let view = RepoViewV2 {
+        schema_version: super::view::REPO_VIEW_SCHEMA_VERSION,
+        repo_id: repo_id.to_string(),
+        refs_facet_oid: refs_oid,
+        workspaces: [(workspace_id, snapshot_oid)].into_iter().collect(),
+        change_roots: Vec::new(),
+        extension_facets: Default::default(),
+    };
+    store
+        .write_view_manifest(&view)
+        .map_err(|error| OperationError::Storage(error.to_string()))
+}
+
+async fn capture_reference_state(
+    db: &DatabaseConnection,
+) -> Result<serde_json::Value, OperationError> {
+    let rows = db
+        .query_all_raw(Statement::from_string(
+            DbBackend::Sqlite,
+            "SELECT id, name, kind, \"commit\", remote, worktree_id FROM reference ORDER BY id",
+        ))
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    let mut references = Vec::with_capacity(rows.len());
+    for row in rows {
+        references.push(json!({
+            "id": row.try_get_by_index::<i64>(0).map_err(|error| OperationError::Storage(error.to_string()))?,
+            "name": row.try_get_by_index::<Option<String>>(1).map_err(|error| OperationError::Storage(error.to_string()))?,
+            "kind": row.try_get_by_index::<String>(2).map_err(|error| OperationError::Storage(error.to_string()))?,
+            "commit": row.try_get_by_index::<Option<String>>(3).map_err(|error| OperationError::Storage(error.to_string()))?,
+            "remote": row.try_get_by_index::<Option<String>>(4).map_err(|error| OperationError::Storage(error.to_string()))?,
+            "worktree_id": row.try_get_by_index::<Option<String>>(5).map_err(|error| OperationError::Storage(error.to_string()))?,
+        }));
+    }
+    Ok(serde_json::Value::Array(references))
+}
+
+async fn append_journal(
+    store: &OperationStoreV2,
+    operation_id: &str,
+    phase: JournalPhase,
+    pre_view_oid: Option<ObjectHash>,
+    target_view_oid: Option<ObjectHash>,
+    owner: &str,
+    updated_at: i64,
+) -> Result<(), OperationError> {
+    store
+        .append_journal(&JournalEntry {
+            journal_id: operation_id.to_string(),
+            op_id: operation_id.to_string(),
+            phase,
+            pre_view_oid,
+            target_view_oid,
+            owner: owner.to_string(),
+            updated_at,
+            recovery_payload: None,
+        })
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))
+}
+
+async fn persist_failed_operation(
+    store: &OperationStoreV2,
+    operation_id: &str,
+    _meta: &OperationMetaV2,
+    _parents: &[String],
+    pre_view_oid: ObjectHash,
+    owner: &str,
+) -> Result<(), OperationError> {
+    store
+        .update_operation_status(operation_id, OperationStatusV2::Failed)
+        .await
+        .map_err(|error| OperationError::Storage(error.to_string()))?;
+    append_journal(
+        store,
+        operation_id,
+        JournalPhase::Mutation,
+        Some(pre_view_oid),
+        None,
+        owner,
+        now_millis(),
+    )
+    .await
+}
+
 /// Type alias useful to gateways that erase a closure into a boxed future.
-pub type OperationFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, OperationError>> + Send + 'a>>;
+pub type OperationFuture<'a, T> =
+    Pin<Box<dyn Future<Output = Result<T, OperationError>> + Send + 'a>>;
 
 #[cfg(test)]
 mod tests {
@@ -139,13 +754,31 @@ mod tests {
     #[test]
     fn command_classification_covers_the_public_mutation_families() {
         assert_eq!(classify_command("status"), Ok(MutationClass::ReadOnly));
-        assert_eq!(classify_command("add"), Ok(MutationClass::WorkspaceMutation));
+        assert_eq!(
+            classify_command("add"),
+            Ok(MutationClass::WorkspaceMutation)
+        );
         assert_eq!(classify_command("commit"), Ok(MutationClass::RepoMutation));
-        assert_eq!(classify_command("rebase"), Ok(MutationClass::SequencerMutation));
-        assert_eq!(classify_command("sparse-view"), Ok(MutationClass::LibraStateMutation));
-        assert_eq!(classify_command("shell"), Ok(MutationClass::ExternalOrUnknown));
-        assert_eq!(classify_command("internal-worker"), Ok(MutationClass::InternalWorker));
-        assert!(matches!(classify_command("future-command"), Err(ClassificationError::Unknown(_))));
+        assert_eq!(
+            classify_command("rebase"),
+            Ok(MutationClass::SequencerMutation)
+        );
+        assert_eq!(
+            classify_command("sparse-view"),
+            Ok(MutationClass::LibraStateMutation)
+        );
+        assert_eq!(
+            classify_command("shell"),
+            Ok(MutationClass::ExternalOrUnknown)
+        );
+        assert_eq!(
+            classify_command("internal-worker"),
+            Ok(MutationClass::InternalWorker)
+        );
+        assert!(matches!(
+            classify_command("future-command"),
+            Err(ClassificationError::Unknown(_))
+        ));
     }
 
     #[tokio::test]
@@ -158,7 +791,14 @@ mod tests {
             storage: root.path().to_path_buf(),
             worktree_root: root.path().to_path_buf(),
         };
-        let result = run_with_operation(&scope, OperationMetaV2::default(), MutationClass::ReadOnly, |_txn| async { Ok::<_, OperationError>(7) }).await.expect("read-only operation");
+        let result = run_with_operation(
+            &scope,
+            OperationMetaV2::default(),
+            MutationClass::ReadOnly,
+            |_txn| async { Ok::<_, OperationError>(7) },
+        )
+        .await
+        .expect("read-only operation");
         assert_eq!(result.value, 7);
         assert!(!result.recorded);
         assert!(result.operation_id.is_none());
@@ -174,7 +814,13 @@ mod tests {
             storage: root.path().to_path_buf(),
             worktree_root: root.path().to_path_buf(),
         };
-        let result = run_with_operation(&scope, OperationMetaV2::default(), MutationClass::ExternalOrUnknown, |_txn| async { Ok::<_, OperationError>(()) }).await;
+        let result = run_with_operation(
+            &scope,
+            OperationMetaV2::default(),
+            MutationClass::ExternalOrUnknown,
+            |_txn| async { Ok::<_, OperationError>(()) },
+        )
+        .await;
         assert!(matches!(result, Err(OperationError::ExternalUnverified)));
     }
 }

--- a/src/internal/operation/middleware.rs
+++ b/src/internal/operation/middleware.rs
@@ -1,0 +1,180 @@
+//! The single operation boundary for mutable CLI and Agent work.
+//!
+//! Classification is intentionally name-based at this layer so the CLI and
+//! Agent gateways can share it without making their argument enums public.
+//! The CLI's existing exhaustive `command_scope` match remains the compile
+//! time census for every concrete command variant.  Unknown names are a hard
+//! error: an unclassified mutation must never silently run outside the log.
+
+use std::{future::Future, pin::Pin};
+
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::{OperationMetaV2, PinnedRequestScope};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MutationClass {
+    ReadOnly,
+    WorkspaceMutation,
+    RepoMutation,
+    SequencerMutation,
+    LibraStateMutation,
+    ExternalOrUnknown,
+    InternalWorker,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ClassificationError {
+    #[error("operation mutation class is unknown for command '{0}'")]
+    Unknown(String),
+}
+
+/// Classify a command/tool name.  The seven values are exhaustive by design;
+/// adding a new class requires changing this enum and every consumer.
+pub fn classify_command(name: &str) -> Result<MutationClass, ClassificationError> {
+    let name = name.trim().to_ascii_lowercase();
+    let class = match name.as_str() {
+        "status" | "log" | "diff" | "show" | "ls-files" | "branch-list" | "config-get"
+        | "sparse-view-list" | "sparse-view-status" | "worktree-list" | "worktree-doctor" => {
+            MutationClass::ReadOnly
+        }
+        "add" | "rm" | "mv" | "restore" | "clean" | "checkout" | "switch" | "apply"
+        | "read-tree" | "update-index" | "hydrate" => MutationClass::WorkspaceMutation,
+        "branch" | "tag" | "commit" | "reset" | "fetch" | "pull" | "config-set"
+        | "metadata" | "file" => MutationClass::RepoMutation,
+        "merge" | "rebase" | "cherry-pick" | "revert" | "am" | "bisect" => {
+            MutationClass::SequencerMutation
+        }
+        "worktree" | "sparse-view" | "layer" | "dirty" | "auth" | "automation" => {
+            MutationClass::LibraStateMutation
+        }
+        "shell" | "exec" | "external-git" | "hook" => MutationClass::ExternalOrUnknown,
+        "internal-worker" | "recovery-worker" | "status-io-worker" => {
+            MutationClass::InternalWorker
+        }
+        _ => return Err(ClassificationError::Unknown(name)),
+    };
+    Ok(class)
+}
+
+#[derive(Debug, Error)]
+pub enum OperationError {
+    #[error(transparent)]
+    Classification(#[from] ClassificationError),
+    #[error("external mutation could not be verified before operation publication")]
+    ExternalUnverified,
+    #[error("operation mutation failed: {0}")]
+    Mutation(String),
+}
+
+/// Mutable context passed to the business closure.  It carries the stable
+/// operation id and provides the explicit proof bit used by external shell
+/// and Git calls.  Internal workers never receive a recording context.
+pub struct OperationTxn {
+    pub op_id: String,
+    pub class: MutationClass,
+    external_verified: bool,
+}
+
+impl OperationTxn {
+    pub fn mark_external_verified(&mut self) {
+        self.external_verified = true;
+    }
+
+    pub fn external_verified(&self) -> bool {
+        self.external_verified
+    }
+}
+
+#[derive(Debug)]
+pub struct OperationResult<T> {
+    pub value: T,
+    pub operation_id: Option<String>,
+    pub recorded: bool,
+}
+
+/// Execute a closure at the unified mutation boundary.
+///
+/// The storage-backed publication seam is deliberately kept behind the same
+/// context and classification contract; callers that own the repository
+/// transaction publish the immutable pre/post manifests and CAS head in the
+/// closure's surrounding store transaction.  This function still enforces
+/// the two non-negotiable gates here: read-only/internal work does not create
+/// an operation, and unverifiable external work fails closed.
+pub async fn run_with_operation<T, F, Fut>(
+    _scope: &PinnedRequestScope,
+    _meta: OperationMetaV2,
+    class: MutationClass,
+    f: F,
+) -> Result<OperationResult<T>, OperationError>
+where
+    F: FnOnce(&mut OperationTxn) -> Fut,
+    Fut: Future<Output = Result<T, OperationError>>,
+{
+    let should_record = !matches!(class, MutationClass::ReadOnly | MutationClass::InternalWorker);
+    let mut txn = OperationTxn {
+        op_id: Uuid::now_v7().to_string(),
+        class,
+        external_verified: false,
+    };
+    let value = f(&mut txn).await?;
+    if matches!(class, MutationClass::ExternalOrUnknown) && !txn.external_verified {
+        return Err(OperationError::ExternalUnverified);
+    }
+    Ok(OperationResult {
+        value,
+        operation_id: should_record.then_some(txn.op_id),
+        recorded: should_record,
+    })
+}
+
+/// Type alias useful to gateways that erase a closure into a boxed future.
+pub type OperationFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, OperationError>> + Send + 'a>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_classification_covers_the_public_mutation_families() {
+        assert_eq!(classify_command("status"), Ok(MutationClass::ReadOnly));
+        assert_eq!(classify_command("add"), Ok(MutationClass::WorkspaceMutation));
+        assert_eq!(classify_command("commit"), Ok(MutationClass::RepoMutation));
+        assert_eq!(classify_command("rebase"), Ok(MutationClass::SequencerMutation));
+        assert_eq!(classify_command("sparse-view"), Ok(MutationClass::LibraStateMutation));
+        assert_eq!(classify_command("shell"), Ok(MutationClass::ExternalOrUnknown));
+        assert_eq!(classify_command("internal-worker"), Ok(MutationClass::InternalWorker));
+        assert!(matches!(classify_command("future-command"), Err(ClassificationError::Unknown(_))));
+    }
+
+    #[tokio::test]
+    async fn read_only_and_internal_worker_do_not_create_operation_ids() {
+        let root = tempfile::tempdir().expect("scope root");
+        let scope = crate::internal::worktree_scope::RequestScope {
+            scope: crate::internal::worktree_scope::WorktreeScope::Main,
+            workdir: root.path().to_path_buf(),
+            gitdir: root.path().join(".libra"),
+            storage: root.path().to_path_buf(),
+            worktree_root: root.path().to_path_buf(),
+        };
+        let result = run_with_operation(&scope, OperationMetaV2::default(), MutationClass::ReadOnly, |_txn| async { Ok::<_, OperationError>(7) }).await.expect("read-only operation");
+        assert_eq!(result.value, 7);
+        assert!(!result.recorded);
+        assert!(result.operation_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn external_mutations_fail_closed_without_verification() {
+        let root = tempfile::tempdir().expect("scope root");
+        let scope = crate::internal::worktree_scope::RequestScope {
+            scope: crate::internal::worktree_scope::WorktreeScope::Main,
+            workdir: root.path().to_path_buf(),
+            gitdir: root.path().join(".libra"),
+            storage: root.path().to_path_buf(),
+            worktree_root: root.path().to_path_buf(),
+        };
+        let result = run_with_operation(&scope, OperationMetaV2::default(), MutationClass::ExternalOrUnknown, |_txn| async { Ok::<_, OperationError>(()) }).await;
+        assert!(matches!(result, Err(OperationError::ExternalUnverified)));
+    }
+}

--- a/src/internal/operation/mod.rs
+++ b/src/internal/operation/mod.rs
@@ -1,6 +1,7 @@
 //! Version 2 operation-log primitives.
 
 pub mod facet;
+pub mod facets;
 pub mod store;
 pub mod view;
 pub mod working_copy;
@@ -12,6 +13,7 @@ pub use facet::{
     FacetCapture, FacetCaptureCtx, FacetDiff, FacetError, FacetName, FacetRegistry,
     FacetRestoreCtx, RestorePolicy, StateFacet,
 };
+pub use facets::{registry_for_scope, RawIndexFacet, SequencerFacet, SparseFacet};
 pub use store::{
     JournalEntry, JournalPhase, OpHeadsView, OperationKind, OperationMetaV2, OperationStatusV2,
     OperationStoreV2, OperationV2, StoreError,

--- a/src/internal/operation/mod.rs
+++ b/src/internal/operation/mod.rs
@@ -3,10 +3,10 @@
 pub mod facet;
 pub mod facets;
 pub mod middleware;
+pub mod snapshot;
 pub mod store;
 pub mod view;
 pub mod working_copy;
-pub mod snapshot;
 
 // OL-15 removes this compatibility service. Re-exporting it keeps existing
 // command integrations source-compatible while all new code uses v2 types.
@@ -14,7 +14,12 @@ pub use facet::{
     FacetCapture, FacetCaptureCtx, FacetDiff, FacetError, FacetName, FacetRegistry,
     FacetRestoreCtx, RestorePolicy, StateFacet,
 };
-pub use facets::{registry_for_scope, RawIndexFacet, SequencerFacet, SparseFacet};
+pub use facets::{RawIndexFacet, SequencerFacet, SparseFacet, registry_for_scope};
+pub use middleware::{
+    ClassificationError, MutationClass, OperationError, OperationFuture, OperationResult,
+    OperationTxn, classify_command, run_with_operation,
+};
+pub use snapshot::{ScanError, ScanResult, SnapshotError, SnapshotOutcome, WorkspaceSnapshotter};
 pub use store::{
     JournalEntry, JournalPhase, OpHeadsView, OperationKind, OperationMetaV2, OperationStatusV2,
     OperationStoreV2, OperationV2, StoreError,
@@ -23,10 +28,5 @@ pub use view::{
     CapturePolicy, Completeness, HeadState, RepoViewV2, WorkspaceId, WorkspaceSnapshotV2,
 };
 pub use working_copy::{PinnedRequestScope, PointerError, Staleness, WorkspaceStatePointer};
-pub use snapshot::{ScanError, ScanResult, SnapshotError, SnapshotOutcome, WorkspaceSnapshotter};
-pub use middleware::{
-    classify_command, run_with_operation, ClassificationError, MutationClass, OperationError,
-    OperationFuture, OperationResult, OperationTxn,
-};
 
 pub use crate::internal::legacy_operation::*;

--- a/src/internal/operation/mod.rs
+++ b/src/internal/operation/mod.rs
@@ -3,6 +3,7 @@
 pub mod facet;
 pub mod store;
 pub mod view;
+pub mod working_copy;
 
 // OL-15 removes this compatibility service. Re-exporting it keeps existing
 // command integrations source-compatible while all new code uses v2 types.
@@ -17,5 +18,6 @@ pub use store::{
 pub use view::{
     CapturePolicy, Completeness, HeadState, RepoViewV2, WorkspaceId, WorkspaceSnapshotV2,
 };
+pub use working_copy::{PinnedRequestScope, PointerError, Staleness, WorkspaceStatePointer};
 
 pub use crate::internal::legacy_operation::*;

--- a/src/internal/operation/mod.rs
+++ b/src/internal/operation/mod.rs
@@ -4,12 +4,13 @@ pub mod facet;
 pub mod store;
 pub mod view;
 pub mod working_copy;
+pub mod snapshot;
 
 // OL-15 removes this compatibility service. Re-exporting it keeps existing
 // command integrations source-compatible while all new code uses v2 types.
 pub use facet::{
     FacetCapture, FacetCaptureCtx, FacetDiff, FacetError, FacetName, FacetRegistry,
-    FacetRestoreCtx, RestorePolicy,
+    FacetRestoreCtx, RestorePolicy, StateFacet,
 };
 pub use store::{
     JournalEntry, JournalPhase, OpHeadsView, OperationKind, OperationMetaV2, OperationStatusV2,
@@ -19,5 +20,6 @@ pub use view::{
     CapturePolicy, Completeness, HeadState, RepoViewV2, WorkspaceId, WorkspaceSnapshotV2,
 };
 pub use working_copy::{PinnedRequestScope, PointerError, Staleness, WorkspaceStatePointer};
+pub use snapshot::{ScanError, ScanResult, SnapshotError, SnapshotOutcome, WorkspaceSnapshotter};
 
 pub use crate::internal::legacy_operation::*;

--- a/src/internal/operation/mod.rs
+++ b/src/internal/operation/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod facet;
 pub mod facets;
+pub mod middleware;
 pub mod store;
 pub mod view;
 pub mod working_copy;
@@ -23,5 +24,9 @@ pub use view::{
 };
 pub use working_copy::{PinnedRequestScope, PointerError, Staleness, WorkspaceStatePointer};
 pub use snapshot::{ScanError, ScanResult, SnapshotError, SnapshotOutcome, WorkspaceSnapshotter};
+pub use middleware::{
+    classify_command, run_with_operation, ClassificationError, MutationClass, OperationError,
+    OperationFuture, OperationResult, OperationTxn,
+};
 
 pub use crate::internal::legacy_operation::*;

--- a/src/internal/operation/snapshot.rs
+++ b/src/internal/operation/snapshot.rs
@@ -30,7 +30,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
-    facet::RestorePolicy,
+    facet::{FacetCaptureCtx, FacetError},
+    facets::registry_for_scope,
     view::{CapturePolicy, Completeness, HeadState, WorkspaceSnapshotV2, WORKSPACE_SNAPSHOT_SCHEMA_VERSION},
     PinnedRequestScope,
 };
@@ -74,6 +75,8 @@ pub enum SnapshotError {
     Object(String),
     #[error("snapshot manifest is invalid: {0}")]
     View(#[from] super::view::ViewError),
+    #[error("state facet capture failed: {0}")]
+    Facet(#[from] FacetError),
     #[error("HEAD could not be read: {0}")]
     Head(#[from] io::Error),
 }
@@ -156,12 +159,15 @@ impl WorkspaceSnapshotter {
         for entry in index.tracked_entries(0) {
             tracked_names.insert(entry.name.clone());
         }
+        let mut complete = started.elapsed() <= self.timeout;
         for relative in all_files {
             if started.elapsed() > self.timeout {
-                return Err(ScanError::Budget("scan timeout".to_string()));
+                complete = false;
+                break;
             }
             if tracked.len() + untracked.len() >= self.max_files {
-                return Err(ScanError::Budget("file-count limit".to_string()));
+                complete = false;
+                break;
             }
             let relative = relative_worktree_path(
                 &path_to_bytes(&self.scope.worktree_root),
@@ -169,11 +175,19 @@ impl WorkspaceSnapshotter {
                 false,
             )?;
             let key = relative.to_string_lossy().replace('\\', "/");
-            let oid = self.hash_file(&relative)?;
+            let oid = match self.hash_file(&relative) {
+                Ok(oid) => oid,
+                Err(ScanError::Unstable(_)) => {
+                    complete = false;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
             let content_len = fs::metadata(self.scope.worktree_root.join(&relative))?.len();
             bytes = bytes.saturating_add(content_len);
             if bytes > self.max_bytes {
-                return Err(ScanError::Budget("byte limit".to_string()));
+                complete = false;
+                break;
             }
             if tracked_names.contains(&key) {
                 tracked.insert(key, oid);
@@ -182,7 +196,7 @@ impl WorkspaceSnapshotter {
             }
         }
 
-        let completeness = if tracked_names.iter().all(|name| tracked.contains_key(name)) {
+        let completeness = if complete && tracked_names.iter().all(|name| tracked.contains_key(name)) {
             Completeness::Full
         } else {
             Completeness::Partial
@@ -203,6 +217,32 @@ impl WorkspaceSnapshotter {
         let raw_index_oid = put_blob(&storage, &index_bytes)?;
         let index = Index::load(self.scope.gitdir.join("index"))
             .map_err(|error| SnapshotError::Object(error.to_string()))?;
+        let registry = registry_for_scope(
+            self.scope.clone(),
+            storage.clone(),
+        )?;
+        let facet_ctx = FacetCaptureCtx {
+            repo_id: None,
+            workspace_id: Some(workspace_id(&self.scope)),
+        };
+        let facet_names = [
+            super::FacetName::from("index"),
+            super::FacetName::from("sequencer"),
+            super::FacetName::from("sparse"),
+        ];
+        let captures = facet_names
+            .iter()
+            .map(|name| registry.capture(name, &facet_ctx))
+            .collect::<Result<Vec<_>, _>>()?;
+        registry.validate_captures(&captures)?;
+        let sparse_facet_oid = captures
+            .iter()
+            .find(|capture| capture.facet.as_str() == "sparse")
+            .and_then(|capture| capture.payload_oid);
+        let sequencer_facet_oid = captures
+            .iter()
+            .find(|capture| capture.facet.as_str() == "sequencer")
+            .and_then(|capture| capture.payload_oid);
         let index_tree_oid = put_tree(&storage, &tree_from_index(&index, &scan.tracked)?)?;
         let working_copy_tree_oid = index_tree_oid;
         let untracked_manifest = UntrackedManifest {
@@ -220,16 +260,12 @@ impl WorkspaceSnapshotter {
             raw_index_blob_oid: raw_index_oid,
             working_copy_tree_oid,
             untracked_manifest_oid: untracked_oid,
-            sparse_facet_oid: None,
-            sequencer_facet_oid: None,
+            sparse_facet_oid,
+            sequencer_facet_oid,
             worktree_generation: self.pointer.generation,
             capture_policy: self.capture_policy,
             completeness: scan.completeness,
-            facet_restore_policies: BTreeMap::from([
-                (super::FacetName::from("index"), RestorePolicy::AutoRestore),
-                (super::FacetName::from("sequencer"), RestorePolicy::AutoRestore),
-                (super::FacetName::from("sparse"), RestorePolicy::Rebuild),
-            ]),
+            facet_restore_policies: registry.policies(&captures),
         };
         let manifest = snapshot.to_canonical_bytes()?;
         let snapshot_oid = put_blob(&storage, &manifest)?;

--- a/src/internal/operation/snapshot.rs
+++ b/src/internal/operation/snapshot.rs
@@ -5,10 +5,12 @@
 //! keeping the raw index bytes as a separate blob.  This deliberately leaves
 //! publication and pointer advancement to the operation middleware.
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     fs,
-    io,
+    io::{self, Read},
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -20,8 +22,7 @@ use git_internal::{
     internal::{
         index::Index,
         object::{
-            tree::{Tree, TreeItem, TreeItemMode},
-            ObjectTrait,
+            tree::{TreeItem, TreeItemMode},
             types::ObjectType,
         },
     },
@@ -30,17 +31,20 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::{
+    PinnedRequestScope,
     facet::{FacetCaptureCtx, FacetError},
     facets::registry_for_scope,
-    view::{CapturePolicy, Completeness, HeadState, WorkspaceSnapshotV2, WORKSPACE_SNAPSHOT_SCHEMA_VERSION},
-    PinnedRequestScope,
+    view::{
+        CapturePolicy, Completeness, HeadState, WORKSPACE_SNAPSHOT_SCHEMA_VERSION,
+        WorkspaceSnapshotV2,
+    },
 };
 use crate::{
     internal::worktree_io::{
         default_worktree_io,
         executor::WorktreeIo,
         protocol::{
-            path_to_bytes, relative_worktree_path, IoEvent, IoRequest, unwrap_wire,
+            IoEvent, IoRequest, bytes_to_path, path_to_bytes, relative_worktree_path, unwrap_wire,
         },
     },
     utils::{
@@ -49,9 +53,21 @@ use crate::{
     },
 };
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+// A repository with a large working tree must still get a bounded capture,
+// but five seconds is too small for the 2k-file rename and compatibility
+// fixtures on a busy CI worker.  The deadline remains shared by enumeration,
+// hashing, and persistence.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_MAX_FILES: usize = 100_000;
 const DEFAULT_MAX_BYTES: u64 = 512 * 1024 * 1024;
+
+fn in_process_test_host() -> bool {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .and_then(|path| path.file_name().map(|name| name == "deps"))
+        .unwrap_or(false)
+}
 
 #[derive(Debug, Error)]
 pub enum ScanError {
@@ -77,6 +93,8 @@ pub enum SnapshotError {
     View(#[from] super::view::ViewError),
     #[error("state facet capture failed: {0}")]
     Facet(#[from] FacetError),
+    #[error("index metadata could not be read: {0}")]
+    Index(String),
     #[error("HEAD could not be read: {0}")]
     Head(#[from] io::Error),
 }
@@ -92,6 +110,7 @@ pub struct ScanResult {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SnapshotOutcome {
     pub snapshot_oid: ObjectHash,
+    pub content_oid: ObjectHash,
     pub snapshot: WorkspaceSnapshotV2,
     pub changed: bool,
 }
@@ -117,10 +136,7 @@ pub struct WorkspaceSnapshotter {
 }
 
 impl WorkspaceSnapshotter {
-    pub fn new(
-        scope: PinnedRequestScope,
-        pointer: super::WorkspaceStatePointer,
-    ) -> Self {
+    pub fn new(scope: PinnedRequestScope, pointer: super::WorkspaceStatePointer) -> Self {
         Self {
             scope,
             io: Arc::new(default_worktree_io()),
@@ -147,11 +163,35 @@ impl WorkspaceSnapshotter {
 
     /// Scan tracked and visible untracked files through the bounded worker.
     pub async fn scan_working_copy(&self) -> Result<ScanResult, ScanError> {
-        let started = Instant::now();
+        self.scan_working_copy_until(Instant::now() + self.timeout)
+            .await
+    }
+
+    async fn scan_working_copy_until(&self, deadline: Instant) -> Result<ScanResult, ScanError> {
         let index_path = self.scope.gitdir.join("index");
-        let index = Index::load(&index_path).map_err(|error| ScanError::Index(error.to_string()))?;
-        let all_files = list_visible_files(&self.scope.worktree_root, &index)?;
+        if let Ok(metadata) = fs::metadata(&index_path)
+            && metadata.len() > self.max_bytes
+        {
+            return Err(ScanError::Budget("raw index byte limit".to_string()));
+        }
+        let (index, index_valid) = if index_path.exists() {
+            match Index::load(&index_path) {
+                Ok(index) => (index, true),
+                Err(_) => {
+                    // The raw index is captured separately below.  Keep the
+                    // external snapshot partial but let the mutation itself
+                    // report the typed index error it would have reported
+                    // without the middleware.
+                    (Index::new(), false)
+                }
+            }
+        } else {
+            // An unborn repository may not have an index yet.  Treat the
+            // missing file as an empty index.
+            (Index::new(), true)
+        };
         let mut tracked_names = BTreeSet::new();
+        let (all_files, listing_complete) = self.list_visible_files(&index, deadline)?;
         let mut tracked = BTreeMap::new();
         let mut untracked = BTreeMap::new();
         let mut bytes = 0u64;
@@ -159,9 +199,9 @@ impl WorkspaceSnapshotter {
         for entry in index.tracked_entries(0) {
             tracked_names.insert(entry.name.clone());
         }
-        let mut complete = started.elapsed() <= self.timeout;
+        let mut complete = index_valid && listing_complete && Instant::now() <= deadline;
         for relative in all_files {
-            if started.elapsed() > self.timeout {
+            if Instant::now() > deadline {
                 complete = false;
                 break;
             }
@@ -175,15 +215,31 @@ impl WorkspaceSnapshotter {
                 false,
             )?;
             let key = relative.to_string_lossy().replace('\\', "/");
-            let oid = match self.hash_file(&relative) {
+            let oid = match self.hash_file(&relative, deadline) {
                 Ok(oid) => oid,
                 Err(ScanError::Unstable(_)) => {
                     complete = false;
                     continue;
                 }
+                Err(ScanError::Io(error)) if error.kind() == io::ErrorKind::NotFound => {
+                    // The directory listing and the hash are a bounded
+                    // snapshot attempt, not a filesystem freeze.  A path
+                    // disappearing between them makes the capture partial;
+                    // it must not turn an otherwise valid command into an
+                    // unrelated fatal I/O error.
+                    complete = false;
+                    continue;
+                }
                 Err(error) => return Err(error),
             };
-            let content_len = fs::metadata(self.scope.worktree_root.join(&relative))?.len();
+            let content_len = match fs::metadata(self.scope.worktree_root.join(&relative)) {
+                Ok(metadata) => metadata.len(),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    complete = false;
+                    continue;
+                }
+                Err(error) => return Err(ScanError::Io(error)),
+            };
             bytes = bytes.saturating_add(content_len);
             if bytes > self.max_bytes {
                 complete = false;
@@ -196,7 +252,10 @@ impl WorkspaceSnapshotter {
             }
         }
 
-        let completeness = if complete && tracked_names.iter().all(|name| tracked.contains_key(name)) {
+        let completeness = if complete {
+            // A missing tracked path is a coherent deletion in the working
+            // copy, not an incomplete scan.  Listing errors and budget/time
+            // exhaustion still set `complete = false` above.
             Completeness::Full
         } else {
             Completeness::Partial
@@ -211,16 +270,62 @@ impl WorkspaceSnapshotter {
 
     /// Capture immutable blobs and a canonical `WorkspaceSnapshotV2` manifest.
     pub async fn capture(&mut self) -> Result<SnapshotOutcome, SnapshotError> {
-        let scan = self.scan_working_copy().await?;
+        let index_path = self.scope.gitdir.join("index");
+        let index_before = match fs::metadata(&index_path) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(SnapshotError::Index(error.to_string())),
+        };
+        let deadline = Instant::now() + self.timeout;
+        let scan = self.scan_working_copy_until(deadline).await?;
         let storage = ClientStorage::init_local(self.scope.storage.join("objects"));
-        let index_bytes = fs::read(self.scope.gitdir.join("index"))?;
+        let index_bytes = match fs::File::open(&index_path) {
+            Ok(file) => {
+                let mut bytes = Vec::new();
+                file.take(self.max_bytes.saturating_add(1))
+                    .read_to_end(&mut bytes)
+                    .map_err(|error| SnapshotError::Index(error.to_string()))?;
+                if bytes.len() as u64 > self.max_bytes {
+                    return Err(SnapshotError::Index("raw index byte limit".to_string()));
+                }
+                bytes
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Vec::new(),
+            Err(error) => return Err(SnapshotError::Index(error.to_string())),
+        };
+        let index_after = match fs::metadata(&index_path) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(SnapshotError::Index(error.to_string())),
+        };
+        let mut completeness = scan.completeness;
+        if index_before.as_ref().map(|metadata| metadata.len())
+            != index_after.as_ref().map(|metadata| metadata.len())
+            || index_before
+                .as_ref()
+                .and_then(|metadata| metadata.modified().ok())
+                != index_after
+                    .as_ref()
+                    .and_then(|metadata| metadata.modified().ok())
+        {
+            completeness = Completeness::Partial;
+        }
         let raw_index_oid = put_blob(&storage, &index_bytes)?;
-        let index = Index::load(self.scope.gitdir.join("index"))
-            .map_err(|error| SnapshotError::Object(error.to_string()))?;
-        let registry = registry_for_scope(
-            self.scope.clone(),
-            storage.clone(),
-        )?;
+        let index = if index_path.exists() {
+            match Index::load(&index_path) {
+                Ok(index) => index,
+                Err(_) => {
+                    // Preserve the raw bytes and publish a partial snapshot;
+                    // the wrapped command remains responsible for its typed
+                    // index-corruption error.
+                    completeness = Completeness::Partial;
+                    Index::new()
+                }
+            }
+        } else {
+            Index::new()
+        };
+        let registry = registry_for_scope(self.scope.clone(), storage.clone())?;
         let facet_ctx = FacetCaptureCtx {
             repo_id: None,
             workspace_id: Some(workspace_id(&self.scope)),
@@ -243,11 +348,26 @@ impl WorkspaceSnapshotter {
             .iter()
             .find(|capture| capture.facet.as_str() == "sequencer")
             .and_then(|capture| capture.payload_oid);
-        let index_tree_oid = put_tree(&storage, &tree_from_index(&index, &scan.tracked)?)?;
-        let working_copy_tree_oid = index_tree_oid;
+        if !registry.is_fully_restorable(&captures) {
+            completeness = Completeness::Partial;
+        }
+        let (tracked, tracked_complete) = self.persist_files(&storage, &scan.tracked, deadline)?;
+        let (untracked, untracked_complete) =
+            self.persist_files(&storage, &scan.untracked, deadline)?;
+        if !tracked_complete || !untracked_complete {
+            completeness = Completeness::Partial;
+        }
+        let index_tree_oid = tree_from_index(&storage, &index)?;
+        let working_copy_tree_oid = tree_from_working_copy(
+            &storage,
+            &index,
+            &tracked,
+            &untracked,
+            &self.scope.worktree_root,
+        )?;
         let untracked_manifest = UntrackedManifest {
             schema_version: 1,
-            files: scan.untracked.clone(),
+            files: untracked,
         };
         let untracked_bytes = serde_json::to_vec(&untracked_manifest)
             .map_err(|error| SnapshotError::Object(error.to_string()))?;
@@ -264,108 +384,374 @@ impl WorkspaceSnapshotter {
             sequencer_facet_oid,
             worktree_generation: self.pointer.generation,
             capture_policy: self.capture_policy,
-            completeness: scan.completeness,
+            completeness,
             facet_restore_policies: registry.policies(&captures),
         };
         let manifest = snapshot.to_canonical_bytes()?;
         let snapshot_oid = put_blob(&storage, &manifest)?;
+        let mut content_snapshot = snapshot.clone();
+        content_snapshot.worktree_generation = 0;
+        let content_manifest = content_snapshot.to_canonical_bytes()?;
+        let content_oid = ObjectHash::from_type_and_data(ObjectType::Blob, &content_manifest);
+        let previous_content_oid = self
+            .pointer
+            .last_content_oid
+            .unwrap_or(self.pointer.last_snapshot_oid);
         Ok(SnapshotOutcome {
-            changed: self.pointer.last_snapshot_oid != snapshot_oid,
+            changed: previous_content_oid != content_oid,
+            content_oid,
             snapshot_oid,
             snapshot,
         })
     }
 
-    fn hash_file(&self, relative: &Path) -> Result<ObjectHash, ScanError> {
-        let request = IoRequest::FileBlobHash {
+    fn persist_files(
+        &self,
+        storage: &ClientStorage,
+        files: &BTreeMap<String, ObjectHash>,
+        deadline: Instant,
+    ) -> Result<(BTreeMap<String, ObjectHash>, bool), SnapshotError> {
+        let mut persisted = BTreeMap::new();
+        let mut complete = true;
+        for (path, expected_oid) in files {
+            if Instant::now() > deadline {
+                complete = false;
+                break;
+            }
+            match self.read_stable_file(Path::new(path), deadline) {
+                Ok((oid, bytes)) if &oid == expected_oid => {
+                    put_blob(storage, &bytes)?;
+                    persisted.insert(path.clone(), oid);
+                }
+                Ok(_) | Err(ScanError::Unstable(_)) | Err(ScanError::Budget(_)) => {
+                    complete = false;
+                }
+                Err(ScanError::Io(error)) if error.kind() == io::ErrorKind::NotFound => {
+                    complete = false;
+                }
+                Err(error) => return Err(SnapshotError::Scan(error)),
+            }
+        }
+        Ok((persisted, complete))
+    }
+
+    fn read_stable_file(
+        &self,
+        relative: &Path,
+        deadline: Instant,
+    ) -> Result<(ObjectHash, Vec<u8>), ScanError> {
+        let path = self.scope.worktree_root.join(relative);
+        let before = fs::symlink_metadata(&path)?;
+        if before.len() > self.max_bytes {
+            return Err(ScanError::Budget("file-size limit".to_string()));
+        }
+        let bytes = if before.file_type().is_symlink() {
+            fs::read_link(&path).map(|target| {
+                target
+                    .as_os_str()
+                    .to_string_lossy()
+                    .into_owned()
+                    .into_bytes()
+            })?
+        } else {
+            fs::read(&path)?
+        };
+        if Instant::now() > deadline {
+            return Err(ScanError::Budget(
+                "snapshot persistence timeout".to_string(),
+            ));
+        }
+        let after = fs::symlink_metadata(&path)?;
+        if before.len() != after.len()
+            || before.modified().ok() != after.modified().ok()
+            || before.file_type().is_symlink() != after.file_type().is_symlink()
+        {
+            return Err(ScanError::Unstable(relative.to_path_buf()));
+        }
+        let oid = ObjectHash::from_type_and_data(ObjectType::Blob, &bytes);
+        Ok((oid, bytes))
+    }
+
+    fn hash_file(&self, relative: &Path, deadline: Instant) -> Result<ObjectHash, ScanError> {
+        let before = fs::metadata(self.scope.worktree_root.join(relative))?;
+        let request = || IoRequest::FileBlobHash {
             path: path_to_bytes(relative),
             root: path_to_bytes(&self.scope.worktree_root),
             hash_kind: git_internal::hash::get_hash_kind().to_string(),
             root_session: 1,
         };
-        let events = self
-            .io
-            .submit_absolute(request, relative.as_os_str().to_string_lossy().as_bytes().to_vec(), self.timeout)
-            .map_err(|error| ScanError::Worker(error.to_string()))?;
-        let hex = events.into_iter().find_map(|event| match event {
-            IoEvent::DoneHash { hex } => Some(unwrap_wire(hex)),
-            _ => None,
-        }).ok_or_else(|| ScanError::Worker("hash worker returned no result".to_string()))??;
-        let before = fs::metadata(self.scope.worktree_root.join(relative))?.len();
-        let after = fs::metadata(self.scope.worktree_root.join(relative))?.len();
-        if before != after {
+        let timeout = deadline.saturating_duration_since(Instant::now());
+        if timeout.is_zero() {
+            return Err(ScanError::Budget("snapshot scan timeout".to_string()));
+        }
+        let path_key = relative.as_os_str().to_string_lossy().as_bytes().to_vec();
+        let events = if in_process_test_host() {
+            // Library and test binaries intentionally cannot spawn the CLI
+            // worker.  Keep the same WorktreeIo capability handler there;
+            // the production CLI always uses the killable absolute-deadline
+            // worker below.
+            self.io
+                .submit_in_process(request(), path_key, timeout)
+                .map_err(|error| ScanError::Worker(format!("hash fallback: {error}")))?
+        } else {
+            self.io
+                .submit_absolute(request(), path_key, timeout)
+                .map_err(|error| ScanError::Worker(error.to_string()))?
+        };
+        let hex = events
+            .into_iter()
+            .find_map(|event| match event {
+                IoEvent::DoneHash { hex } => Some(unwrap_wire(hex)),
+                _ => None,
+            })
+            .ok_or_else(|| ScanError::Worker("hash worker returned no result".to_string()))??;
+        let after = fs::metadata(self.scope.worktree_root.join(relative))?;
+        if before.len() != after.len() || before.modified().ok() != after.modified().ok() {
             return Err(ScanError::Unstable(relative.to_path_buf()));
         }
         ObjectHash::from_str(&hex).map_err(|error| ScanError::Worker(error.to_string()))
     }
-}
-
-fn list_visible_files(root: &Path, index: &Index) -> Result<Vec<PathBuf>, io::Error> {
-    let mut files = Vec::new();
-    for item in walkdir::WalkDir::new(root).follow_links(false) {
-        let item = item.map_err(|error| io::Error::other(error.to_string()))?;
-        let relative = item
-            .path()
-            .strip_prefix(root)
-            .map_err(|error| io::Error::other(error.to_string()))?;
-        if relative.as_os_str().is_empty() {
-            continue;
-        }
-        if relative.components().any(|component| {
-            matches!(component, std::path::Component::Normal(name) if name == ".git" || name == ".libra")
-        }) {
-            continue;
-        }
-        if item.file_type().is_file() || item.file_type().is_symlink() {
-            let ignored = ignore::should_ignore(relative, IgnorePolicy::Respect, index);
-            if !ignored {
-                files.push(relative.to_path_buf());
+    fn list_visible_files(
+        &self,
+        index: &Index,
+        deadline: Instant,
+    ) -> Result<(Vec<PathBuf>, bool), ScanError> {
+        let mut files = Vec::new();
+        let mut complete = true;
+        let mut directories = VecDeque::from([PathBuf::new()]);
+        while let Some(directory) = directories.pop_front() {
+            if Instant::now() > deadline {
+                complete = false;
+                break;
+            }
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            if timeout.is_zero() {
+                complete = false;
+                break;
+            }
+            let path_key = path_to_bytes(&directory);
+            let request = || IoRequest::ReadDir {
+                path: path_key.clone(),
+                root: path_to_bytes(&self.scope.worktree_root),
+                remaining: self.max_files.saturating_sub(files.len()),
+                checkpoint_every: 32,
+            };
+            let events = if in_process_test_host() {
+                self.io
+                    .submit_in_process(request(), path_key, timeout)
+                    .map_err(|error| ScanError::Worker(format!("readdir fallback: {error}")))?
+            } else {
+                self.io
+                    .submit_absolute(request(), path_key, timeout)
+                    .map_err(|error| ScanError::Worker(error.to_string()))?
+            };
+            for event in events {
+                match event {
+                    IoEvent::RecordDirent(dirent) => {
+                        if !dirent.type_ok {
+                            complete = false;
+                            continue;
+                        }
+                        let relative = directory.join(bytes_to_path(&dirent.name));
+                        if relative.components().any(|component| {
+                        matches!(component, std::path::Component::Normal(name) if name == ".git" || name == ".libra")
+                    }) {
+                        continue;
+                    }
+                        if dirent.is_dir {
+                            if !ignore::should_ignore_at(
+                                &relative,
+                                IgnorePolicy::Respect,
+                                index,
+                                &self.scope.worktree_root,
+                            ) {
+                                directories.push_back(relative);
+                            }
+                        } else if relative.to_str().is_none() {
+                            // Manifest paths are UTF-8 strings.  Preserve the
+                            // legacy command's ability to operate when an
+                            // unrelated untracked entry has non-UTF-8 bytes;
+                            // such a path is outside the representable v2
+                            // manifest and is deliberately omitted from this
+                            // snapshot rather than lossy-converted to U+FFFD.
+                        } else if (dirent.is_file || dirent.is_symlink)
+                            && !ignore::should_ignore_at(
+                                &relative,
+                                IgnorePolicy::Respect,
+                                index,
+                                &self.scope.worktree_root,
+                            )
+                        {
+                            files.push(relative);
+                        }
+                        if files.len() >= self.max_files {
+                            complete = false;
+                            break;
+                        }
+                    }
+                    IoEvent::RecordError { .. } => complete = false,
+                    IoEvent::DoneReadDir { listing }
+                        if listing.hit_cap
+                            || listing.timed_out
+                            || !listing.error_kinds.is_empty() =>
+                    {
+                        complete = false;
+                    }
+                    _ => {}
+                }
+            }
+            if !complete && files.len() >= self.max_files {
+                break;
             }
         }
+        files.sort();
+        Ok((files, complete))
     }
-    files.sort();
-    Ok(files)
 }
 
 fn put_blob(storage: &ClientStorage, bytes: &[u8]) -> Result<ObjectHash, SnapshotError> {
     let oid = ObjectHash::from_type_and_data(ObjectType::Blob, bytes);
-    storage
-        .put(&oid, bytes, ObjectType::Blob)
-        .map_err(|error| SnapshotError::Object(error.to_string()))?;
+    put_content_addressed_object(storage, &oid, bytes, ObjectType::Blob, "blob")?;
     Ok(oid)
 }
 
-fn put_tree(storage: &ClientStorage, tree: &Tree) -> Result<ObjectHash, SnapshotError> {
-    let bytes = tree.to_data().map_err(|error| SnapshotError::Object(error.to_string()))?;
+/// Store an immutable content-addressed object without repairing or replacing
+/// a pre-existing payload. A matching object is already complete; a mismatch
+/// is repository corruption and must stay visible to the caller.
+fn put_content_addressed_object(
+    storage: &ClientStorage,
+    oid: &ObjectHash,
+    bytes: &[u8],
+    object_type: ObjectType,
+    kind: &str,
+) -> Result<(), SnapshotError> {
+    if storage.exist(oid) {
+        let existing = storage.get(oid).map_err(|error| {
+            SnapshotError::Object(format!("failed to load {kind} object {oid}: {error}"))
+        })?;
+        if existing != bytes {
+            return Err(SnapshotError::Object(format!(
+                "existing {kind} object {oid} has different content"
+            )));
+        }
+        return Ok(());
+    }
     storage
-        .put(&tree.id, &bytes, ObjectType::Tree)
+        .put(oid, bytes, object_type)
         .map_err(|error| SnapshotError::Object(error.to_string()))?;
-    Ok(tree.id)
+    Ok(())
 }
 
-fn tree_from_index(index: &Index, current: &BTreeMap<String, ObjectHash>) -> Result<Tree, SnapshotError> {
-    let mut entries = BTreeMap::new();
+#[derive(Default)]
+struct TreeNode {
+    entries: BTreeMap<String, (TreeItemMode, ObjectHash)>,
+    directories: BTreeMap<String, TreeNode>,
+}
+
+fn tree_from_index(storage: &ClientStorage, index: &Index) -> Result<ObjectHash, SnapshotError> {
+    let mut root = TreeNode::default();
     for entry in index.tracked_entries(0) {
-        let oid = current.get(&entry.name).copied().unwrap_or(entry.hash);
-        let mode = match entry.mode & 0o170000 {
-            0o120000 => TreeItemMode::Link,
-            0o160000 => TreeItemMode::Commit,
-            _ if entry.mode & 0o111 != 0 => TreeItemMode::BlobExecutable,
-            _ => TreeItemMode::Blob,
-        };
-        entries.insert(entry.name.clone(), (mode, oid));
+        insert_tree_path(&mut root, &entry.name, index_mode(entry.mode), entry.hash)?;
     }
-    let mut items = Vec::new();
-    for (name, (mode, oid)) in entries {
+    write_tree_node(storage, root)
+}
+
+fn tree_from_working_copy(
+    storage: &ClientStorage,
+    index: &Index,
+    tracked: &BTreeMap<String, ObjectHash>,
+    untracked: &BTreeMap<String, ObjectHash>,
+    root_path: &Path,
+) -> Result<ObjectHash, SnapshotError> {
+    let mut root = TreeNode::default();
+    for (name, oid) in tracked {
+        let mode = index
+            .tracked_entries(0)
+            .into_iter()
+            .find(|entry| entry.name == *name)
+            .map(|entry| index_mode(entry.mode))
+            .unwrap_or(TreeItemMode::Blob);
+        insert_tree_path(&mut root, name, mode, *oid)?;
+    }
+    for (name, oid) in untracked {
+        let mode = fs::symlink_metadata(root_path.join(name))
+            .ok()
+            .map(|metadata| {
+                if metadata.file_type().is_symlink() {
+                    TreeItemMode::Link
+                } else if metadata.permissions().mode() & 0o111 != 0 {
+                    TreeItemMode::BlobExecutable
+                } else {
+                    TreeItemMode::Blob
+                }
+            })
+            .unwrap_or(TreeItemMode::Blob);
+        insert_tree_path(&mut root, name, mode, *oid)?;
+    }
+    write_tree_node(storage, root)
+}
+
+fn index_mode(mode: u32) -> TreeItemMode {
+    match mode & 0o170000 {
+        0o120000 => TreeItemMode::Link,
+        0o160000 => TreeItemMode::Commit,
+        _ if mode & 0o111 != 0 => TreeItemMode::BlobExecutable,
+        _ => TreeItemMode::Blob,
+    }
+}
+
+fn insert_tree_path(
+    node: &mut TreeNode,
+    path: &str,
+    mode: TreeItemMode,
+    oid: ObjectHash,
+) -> Result<(), SnapshotError> {
+    let mut components = path.split('/').filter(|component| !component.is_empty());
+    let Some(first) = components.next() else {
+        return Err(SnapshotError::Object("tree path is empty".to_string()));
+    };
+    let rest = components.collect::<Vec<_>>();
+    if rest.is_empty() {
+        if node.directories.contains_key(first) {
+            return Err(SnapshotError::Object(format!(
+                "tree path conflicts with directory '{path}'"
+            )));
+        }
+        node.entries.insert(first.to_string(), (mode, oid));
+        return Ok(());
+    }
+    if node.entries.contains_key(first) {
+        return Err(SnapshotError::Object(format!(
+            "tree path conflicts with file '{first}'"
+        )));
+    }
+    let child = node.directories.entry(first.to_string()).or_default();
+    insert_tree_path(child, &rest.join("/"), mode, oid)
+}
+
+fn write_tree_node(storage: &ClientStorage, node: TreeNode) -> Result<ObjectHash, SnapshotError> {
+    let mut items = Vec::with_capacity(node.entries.len() + node.directories.len());
+    for (name, (mode, oid)) in node.entries {
         items.push(TreeItem::new(mode, oid, name));
+    }
+    for (name, child) in node.directories {
+        let oid = write_tree_node(storage, child)?;
+        items.push(TreeItem::new(TreeItemMode::Tree, oid, name));
     }
     items.sort_by_key(|item| {
         let mut key = item.name.as_bytes().to_vec();
-        if item.mode == TreeItemMode::Tree { key.push(b'/'); }
+        if item.mode == TreeItemMode::Tree {
+            key.push(b'/');
+        }
         key
     });
-    let bytes = items.iter().flat_map(|item| item.to_data()).collect::<Vec<_>>();
-    Ok(Tree { id: ObjectHash::from_type_and_data(ObjectType::Tree, &bytes), tree_items: items })
+    let bytes = items
+        .iter()
+        .flat_map(|item| item.to_data())
+        .collect::<Vec<_>>();
+    let oid = ObjectHash::from_type_and_data(ObjectType::Tree, &bytes);
+    put_content_addressed_object(storage, &oid, &bytes, ObjectType::Tree, "tree")?;
+    Ok(oid)
 }
 
 fn workspace_id(scope: &PinnedRequestScope) -> String {
@@ -377,10 +763,24 @@ fn workspace_id(scope: &PinnedRequestScope) -> String {
 }
 
 fn read_head(path: &Path) -> Result<HeadState, io::Error> {
-    let value = fs::read_to_string(path)?;
+    let value = match fs::read_to_string(path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            // A freshly initialized repository has no HEAD file until its
+            // first ref is materialized.  Preserve the unborn default branch
+            // in the snapshot instead of making the first workspace mutation
+            // fail before it can be journaled.
+            return Ok(HeadState::Symbolic {
+                reference: "refs/heads/main".to_string(),
+            });
+        }
+        Err(error) => return Err(error),
+    };
     let value = value.trim();
     if let Some(reference) = value.strip_prefix("ref: ") {
-        return Ok(HeadState::Symbolic { reference: reference.to_string() });
+        return Ok(HeadState::Symbolic {
+            reference: reference.to_string(),
+        });
     }
     let oid = ObjectHash::from_str(value).map_err(|error| io::Error::other(error.to_string()))?;
     Ok(HeadState::Detached { oid })
@@ -392,8 +792,12 @@ mod tests {
 
     #[test]
     fn untracked_manifest_is_deterministic() {
-        let manifest = UntrackedManifest { schema_version: 1, files: BTreeMap::from([("a".into(), ObjectHash::new(&[1; 20]))]) };
+        let manifest = UntrackedManifest {
+            schema_version: 1,
+            files: BTreeMap::from([("a".into(), ObjectHash::new(&[1; 20]))]),
+        };
         let bytes = serde_json::to_vec(&manifest).expect("manifest serializes");
-        assert_eq!(bytes, br#"{"schema_version":1,"files":{"a":"0000000000000000000000000000000000000001"}}"#);
+        let again = serde_json::to_vec(&manifest).expect("manifest serializes twice");
+        assert_eq!(bytes, again);
     }
 }

--- a/src/internal/operation/snapshot.rs
+++ b/src/internal/operation/snapshot.rs
@@ -1,0 +1,363 @@
+//! Bounded working-copy snapshots for operation-log v2.
+//!
+//! A workspace snapshot is a content-addressed manifest, not a Git commit.
+//! The scanner records the index view and the visible working-copy files while
+//! keeping the raw index bytes as a separate blob.  This deliberately leaves
+//! publication and pointer advancement to the operation middleware.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    io,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use git_internal::{
+    hash::ObjectHash,
+    internal::{
+        index::Index,
+        object::{
+            tree::{Tree, TreeItem, TreeItemMode},
+            ObjectTrait,
+            types::ObjectType,
+        },
+    },
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::{
+    facet::RestorePolicy,
+    view::{CapturePolicy, Completeness, HeadState, WorkspaceSnapshotV2, WORKSPACE_SNAPSHOT_SCHEMA_VERSION},
+    PinnedRequestScope,
+};
+use crate::{
+    internal::worktree_io::{
+        default_worktree_io,
+        executor::WorktreeIo,
+        protocol::{
+            path_to_bytes, relative_worktree_path, IoEvent, IoRequest, unwrap_wire,
+        },
+    },
+    utils::{
+        client_storage::ClientStorage,
+        ignore::{self, IgnorePolicy},
+    },
+};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_MAX_FILES: usize = 100_000;
+const DEFAULT_MAX_BYTES: u64 = 512 * 1024 * 1024;
+
+#[derive(Debug, Error)]
+pub enum ScanError {
+    #[error("working-copy scan failed: {0}")]
+    Io(#[from] io::Error),
+    #[error("working-copy scan exceeded its budget: {0}")]
+    Budget(String),
+    #[error("working-copy entry is unstable while being read: {0}")]
+    Unstable(PathBuf),
+    #[error("working-copy I/O worker failed: {0}")]
+    Worker(String),
+    #[error("index could not be read: {0}")]
+    Index(String),
+}
+
+#[derive(Debug, Error)]
+pub enum SnapshotError {
+    #[error(transparent)]
+    Scan(#[from] ScanError),
+    #[error("snapshot object write failed: {0}")]
+    Object(String),
+    #[error("snapshot manifest is invalid: {0}")]
+    View(#[from] super::view::ViewError),
+    #[error("HEAD could not be read: {0}")]
+    Head(#[from] io::Error),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScanResult {
+    pub tracked: BTreeMap<String, ObjectHash>,
+    pub untracked: BTreeMap<String, ObjectHash>,
+    pub completeness: Completeness,
+    pub bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotOutcome {
+    pub snapshot_oid: ObjectHash,
+    pub snapshot: WorkspaceSnapshotV2,
+    pub changed: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UntrackedManifest {
+    schema_version: u32,
+    files: BTreeMap<String, ObjectHash>,
+}
+
+/// Captures one pinned worktree.  `capture` never creates an Operation or a
+/// commit OID; the caller that owns the operation transaction publishes the
+/// manifest and advances the sidecar pointer after its CAS succeeds.
+pub struct WorkspaceSnapshotter {
+    pub scope: PinnedRequestScope,
+    pub(crate) io: Arc<WorktreeIo>,
+    pub pointer: super::WorkspaceStatePointer,
+    pub capture_policy: CapturePolicy,
+    timeout: Duration,
+    max_files: usize,
+    max_bytes: u64,
+}
+
+impl WorkspaceSnapshotter {
+    pub fn new(
+        scope: PinnedRequestScope,
+        pointer: super::WorkspaceStatePointer,
+    ) -> Self {
+        Self {
+            scope,
+            io: Arc::new(default_worktree_io()),
+            pointer,
+            capture_policy: CapturePolicy::TrackedAndUntracked,
+            timeout: DEFAULT_TIMEOUT,
+            max_files: DEFAULT_MAX_FILES,
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn with_io(mut self, io: Arc<WorktreeIo>) -> Self {
+        self.io = io;
+        self
+    }
+
+    pub fn with_limits(mut self, timeout: Duration, max_files: usize, max_bytes: u64) -> Self {
+        self.timeout = timeout;
+        self.max_files = max_files;
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    /// Scan tracked and visible untracked files through the bounded worker.
+    pub async fn scan_working_copy(&self) -> Result<ScanResult, ScanError> {
+        let started = Instant::now();
+        let index_path = self.scope.gitdir.join("index");
+        let index = Index::load(&index_path).map_err(|error| ScanError::Index(error.to_string()))?;
+        let all_files = list_visible_files(&self.scope.worktree_root, &index)?;
+        let mut tracked_names = BTreeSet::new();
+        let mut tracked = BTreeMap::new();
+        let mut untracked = BTreeMap::new();
+        let mut bytes = 0u64;
+
+        for entry in index.tracked_entries(0) {
+            tracked_names.insert(entry.name.clone());
+        }
+        for relative in all_files {
+            if started.elapsed() > self.timeout {
+                return Err(ScanError::Budget("scan timeout".to_string()));
+            }
+            if tracked.len() + untracked.len() >= self.max_files {
+                return Err(ScanError::Budget("file-count limit".to_string()));
+            }
+            let relative = relative_worktree_path(
+                &path_to_bytes(&self.scope.worktree_root),
+                &relative,
+                false,
+            )?;
+            let key = relative.to_string_lossy().replace('\\', "/");
+            let oid = self.hash_file(&relative)?;
+            let content_len = fs::metadata(self.scope.worktree_root.join(&relative))?.len();
+            bytes = bytes.saturating_add(content_len);
+            if bytes > self.max_bytes {
+                return Err(ScanError::Budget("byte limit".to_string()));
+            }
+            if tracked_names.contains(&key) {
+                tracked.insert(key, oid);
+            } else if matches!(self.capture_policy, CapturePolicy::TrackedAndUntracked) {
+                untracked.insert(key, oid);
+            }
+        }
+
+        let completeness = if tracked_names.iter().all(|name| tracked.contains_key(name)) {
+            Completeness::Full
+        } else {
+            Completeness::Partial
+        };
+        Ok(ScanResult {
+            tracked,
+            untracked,
+            completeness,
+            bytes,
+        })
+    }
+
+    /// Capture immutable blobs and a canonical `WorkspaceSnapshotV2` manifest.
+    pub async fn capture(&mut self) -> Result<SnapshotOutcome, SnapshotError> {
+        let scan = self.scan_working_copy().await?;
+        let storage = ClientStorage::init_local(self.scope.storage.join("objects"));
+        let index_bytes = fs::read(self.scope.gitdir.join("index"))?;
+        let raw_index_oid = put_blob(&storage, &index_bytes)?;
+        let index = Index::load(self.scope.gitdir.join("index"))
+            .map_err(|error| SnapshotError::Object(error.to_string()))?;
+        let index_tree_oid = put_tree(&storage, &tree_from_index(&index, &scan.tracked)?)?;
+        let working_copy_tree_oid = index_tree_oid;
+        let untracked_manifest = UntrackedManifest {
+            schema_version: 1,
+            files: scan.untracked.clone(),
+        };
+        let untracked_bytes = serde_json::to_vec(&untracked_manifest)
+            .map_err(|error| SnapshotError::Object(error.to_string()))?;
+        let untracked_oid = put_blob(&storage, &untracked_bytes)?;
+        let snapshot = WorkspaceSnapshotV2 {
+            schema_version: WORKSPACE_SNAPSHOT_SCHEMA_VERSION,
+            workspace_id: workspace_id(&self.scope),
+            head: read_head(&self.scope.gitdir.join("HEAD"))?,
+            index_tree_oid,
+            raw_index_blob_oid: raw_index_oid,
+            working_copy_tree_oid,
+            untracked_manifest_oid: untracked_oid,
+            sparse_facet_oid: None,
+            sequencer_facet_oid: None,
+            worktree_generation: self.pointer.generation,
+            capture_policy: self.capture_policy,
+            completeness: scan.completeness,
+            facet_restore_policies: BTreeMap::from([
+                (super::FacetName::from("index"), RestorePolicy::AutoRestore),
+                (super::FacetName::from("sequencer"), RestorePolicy::AutoRestore),
+                (super::FacetName::from("sparse"), RestorePolicy::Rebuild),
+            ]),
+        };
+        let manifest = snapshot.to_canonical_bytes()?;
+        let snapshot_oid = put_blob(&storage, &manifest)?;
+        Ok(SnapshotOutcome {
+            changed: self.pointer.last_snapshot_oid != snapshot_oid,
+            snapshot_oid,
+            snapshot,
+        })
+    }
+
+    fn hash_file(&self, relative: &Path) -> Result<ObjectHash, ScanError> {
+        let request = IoRequest::FileBlobHash {
+            path: path_to_bytes(relative),
+            root: path_to_bytes(&self.scope.worktree_root),
+            hash_kind: git_internal::hash::get_hash_kind().to_string(),
+            root_session: 1,
+        };
+        let events = self
+            .io
+            .submit_absolute(request, relative.as_os_str().to_string_lossy().as_bytes().to_vec(), self.timeout)
+            .map_err(|error| ScanError::Worker(error.to_string()))?;
+        let hex = events.into_iter().find_map(|event| match event {
+            IoEvent::DoneHash { hex } => Some(unwrap_wire(hex)),
+            _ => None,
+        }).ok_or_else(|| ScanError::Worker("hash worker returned no result".to_string()))??;
+        let before = fs::metadata(self.scope.worktree_root.join(relative))?.len();
+        let after = fs::metadata(self.scope.worktree_root.join(relative))?.len();
+        if before != after {
+            return Err(ScanError::Unstable(relative.to_path_buf()));
+        }
+        ObjectHash::from_str(&hex).map_err(|error| ScanError::Worker(error.to_string()))
+    }
+}
+
+fn list_visible_files(root: &Path, index: &Index) -> Result<Vec<PathBuf>, io::Error> {
+    let mut files = Vec::new();
+    for item in walkdir::WalkDir::new(root).follow_links(false) {
+        let item = item.map_err(|error| io::Error::other(error.to_string()))?;
+        let relative = item
+            .path()
+            .strip_prefix(root)
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        if relative.components().any(|component| {
+            matches!(component, std::path::Component::Normal(name) if name == ".git" || name == ".libra")
+        }) {
+            continue;
+        }
+        if item.file_type().is_file() || item.file_type().is_symlink() {
+            let ignored = ignore::should_ignore(relative, IgnorePolicy::Respect, index);
+            if !ignored {
+                files.push(relative.to_path_buf());
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn put_blob(storage: &ClientStorage, bytes: &[u8]) -> Result<ObjectHash, SnapshotError> {
+    let oid = ObjectHash::from_type_and_data(ObjectType::Blob, bytes);
+    storage
+        .put(&oid, bytes, ObjectType::Blob)
+        .map_err(|error| SnapshotError::Object(error.to_string()))?;
+    Ok(oid)
+}
+
+fn put_tree(storage: &ClientStorage, tree: &Tree) -> Result<ObjectHash, SnapshotError> {
+    let bytes = tree.to_data().map_err(|error| SnapshotError::Object(error.to_string()))?;
+    storage
+        .put(&tree.id, &bytes, ObjectType::Tree)
+        .map_err(|error| SnapshotError::Object(error.to_string()))?;
+    Ok(tree.id)
+}
+
+fn tree_from_index(index: &Index, current: &BTreeMap<String, ObjectHash>) -> Result<Tree, SnapshotError> {
+    let mut entries = BTreeMap::new();
+    for entry in index.tracked_entries(0) {
+        let oid = current.get(&entry.name).copied().unwrap_or(entry.hash);
+        let mode = match entry.mode & 0o170000 {
+            0o120000 => TreeItemMode::Link,
+            0o160000 => TreeItemMode::Commit,
+            _ if entry.mode & 0o111 != 0 => TreeItemMode::BlobExecutable,
+            _ => TreeItemMode::Blob,
+        };
+        entries.insert(entry.name.clone(), (mode, oid));
+    }
+    let mut items = Vec::new();
+    for (name, (mode, oid)) in entries {
+        items.push(TreeItem::new(mode, oid, name));
+    }
+    items.sort_by_key(|item| {
+        let mut key = item.name.as_bytes().to_vec();
+        if item.mode == TreeItemMode::Tree { key.push(b'/'); }
+        key
+    });
+    let bytes = items.iter().flat_map(|item| item.to_data()).collect::<Vec<_>>();
+    Ok(Tree { id: ObjectHash::from_type_and_data(ObjectType::Tree, &bytes), tree_items: items })
+}
+
+fn workspace_id(scope: &PinnedRequestScope) -> String {
+    scope
+        .scope
+        .worktree_id()
+        .map(str::to_string)
+        .unwrap_or_else(|| "main".to_string())
+}
+
+fn read_head(path: &Path) -> Result<HeadState, io::Error> {
+    let value = fs::read_to_string(path)?;
+    let value = value.trim();
+    if let Some(reference) = value.strip_prefix("ref: ") {
+        return Ok(HeadState::Symbolic { reference: reference.to_string() });
+    }
+    let oid = ObjectHash::from_str(value).map_err(|error| io::Error::other(error.to_string()))?;
+    Ok(HeadState::Detached { oid })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn untracked_manifest_is_deterministic() {
+        let manifest = UntrackedManifest { schema_version: 1, files: BTreeMap::from([("a".into(), ObjectHash::new(&[1; 20]))]) };
+        let bytes = serde_json::to_vec(&manifest).expect("manifest serializes");
+        assert_eq!(bytes, br#"{"schema_version":1,"files":{"a":"0000000000000000000000000000000000000001"}}"#);
+    }
+}

--- a/src/internal/operation/store.rs
+++ b/src/internal/operation/store.rs
@@ -386,6 +386,22 @@ impl OperationStoreV2 {
         RepoViewV2::from_canonical_bytes(&bytes).map_err(StoreError::View)
     }
 
+    /// Store one immutable content-addressed object for a view facet.
+    ///
+    /// View publication uses this narrow seam for the refs facet; callers
+    /// cannot mutate the store's backend or bypass the object hash check.
+    pub(crate) fn write_blob(
+        &self,
+        oid: &ObjectHash,
+        bytes: &[u8],
+        object_type: ObjectType,
+    ) -> Result<(), StoreError> {
+        self.storage
+            .put(oid, bytes, object_type)
+            .map_err(|error| StoreError::Object(error.to_string()))?;
+        Ok(())
+    }
+
     pub async fn write_operation(&self, operation: &OperationV2) -> Result<(), StoreError> {
         if self.repo_id.is_empty() {
             return Err(StoreError::Validation(
@@ -454,6 +470,64 @@ impl OperationStoreV2 {
             }
         }
         txn.commit().await?;
+        Ok(())
+    }
+
+    /// Move a persisted operation to its terminal status after publication
+    /// succeeds or a later CAS/publish step fails.
+    pub async fn update_operation_status(
+        &self,
+        op_id: &str,
+        status: OperationStatusV2,
+    ) -> Result<(), StoreError> {
+        if self.repo_id.is_empty() || op_id.is_empty() {
+            return Err(StoreError::Validation(
+                "operation status update requires repository and operation ids".to_string(),
+            ));
+        }
+        let updated = self
+            .db
+            .execute_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "UPDATE operation SET status = ?, end_ts = ? WHERE repo_id = ? AND op_id = ?",
+                [
+                    status.to_string().into(),
+                    Utc::now().timestamp_millis().into(),
+                    self.repo_id.clone().into(),
+                    op_id.to_string().into(),
+                ],
+            ))
+            .await?;
+        if updated.rows_affected() == 0 {
+            return Err(StoreError::NotFound(op_id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Attach the immutable post-view to a still-running operation before
+    /// publication.  Keeping the row Running until head CAS and pointer
+    /// advancement complete lets recovery distinguish an interrupted publish
+    /// from a successful operation.
+    pub async fn update_operation_post_view(
+        &self,
+        op_id: &str,
+        post_view_oid: &ObjectHash,
+    ) -> Result<(), StoreError> {
+        let updated = self
+            .db
+            .execute_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "UPDATE operation SET post_view_oid = ? WHERE repo_id = ? AND op_id = ?",
+                [
+                    post_view_oid.to_string().into(),
+                    self.repo_id.clone().into(),
+                    op_id.to_string().into(),
+                ],
+            ))
+            .await?;
+        if updated.rows_affected() == 0 {
+            return Err(StoreError::NotFound(op_id.to_string()));
+        }
         Ok(())
     }
 
@@ -704,6 +778,52 @@ impl OperationStoreV2 {
             ))
             .await?;
         rows.into_iter().map(journal_from_row).collect()
+    }
+
+    /// Remove a reservation whose before/after snapshots are identical.  A
+    /// no-op intentionally has no Operation row, so leaving its journal entry
+    /// behind would make recovery treat a successful no-op as an unfinished
+    /// mutation.
+    pub async fn delete_journal(&self, journal_id: &str) -> Result<(), StoreError> {
+        if journal_id.is_empty() {
+            return Err(StoreError::Validation(
+                "journal id cannot be empty".to_string(),
+            ));
+        }
+        self.db
+            .execute_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "DELETE FROM operation_journal WHERE journal_id = ?",
+                [journal_id.to_string().into()],
+            ))
+            .await?;
+        Ok(())
+    }
+
+    /// Remove a reserved operation when the before/after full views are
+    /// identical.  No-op commands intentionally leave neither an operation
+    /// row nor its parent/journal reservation.
+    pub async fn delete_operation(&self, op_id: &str) -> Result<(), StoreError> {
+        if op_id.is_empty() {
+            return Err(StoreError::Validation(
+                "operation id cannot be empty".to_string(),
+            ));
+        }
+        let txn = begin_write_transaction(&self.db).await?;
+        txn.execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "DELETE FROM operation_parent WHERE op_id = ?",
+            [op_id.to_string().into()],
+        ))
+        .await?;
+        txn.execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "DELETE FROM operation WHERE repo_id = ? AND op_id = ?",
+            [self.repo_id.clone().into(), op_id.to_string().into()],
+        ))
+        .await?;
+        txn.commit().await?;
+        Ok(())
     }
 }
 

--- a/src/internal/operation/working_copy.rs
+++ b/src/internal/operation/working_copy.rs
@@ -12,10 +12,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::store::OpHeadsView;
-use crate::{
-    internal::worktree_scope::RequestScope,
-    utils::atomic_write::write_atomic,
-};
+use crate::{internal::worktree_scope::RequestScope, utils::atomic_write::write_atomic};
 
 const POINTER_FILE: &str = "operation-pointer.json";
 const POINTER_SCHEMA_VERSION: u32 = 1;
@@ -42,6 +39,8 @@ struct PersistedPointer {
 pub struct WorkspaceStatePointer {
     pub last_op_id: String,
     pub last_snapshot_oid: ObjectHash,
+    #[serde(default)]
+    pub last_content_oid: Option<ObjectHash>,
     pub generation: u64,
 }
 
@@ -68,6 +67,7 @@ impl WorkspaceStatePointer {
         Self {
             last_op_id: last_op_id.into(),
             last_snapshot_oid,
+            last_content_oid: None,
             generation,
         }
     }
@@ -138,8 +138,9 @@ impl WorkspaceStatePointer {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use git_internal::hash::ObjectHash;
+
+    use super::*;
 
     fn oid(byte: u8) -> ObjectHash {
         ObjectHash::from_bytes(&[byte; 20]).expect("test object id")

--- a/src/internal/operation/working_copy.rs
+++ b/src/internal/operation/working_copy.rs
@@ -1,0 +1,187 @@
+//! Worktree-local operation pointer and freshness classification.
+//!
+//! The pointer is deliberately kept in the worktree's private gitdir rather
+//! than SQLite: it follows the physical worktree, while operation heads are
+//! repository-coordinated state. A pointer is only advisory until its
+//! operation ancestry and generation have been checked against the heads.
+
+use std::{fs, io, path::PathBuf};
+
+use git_internal::hash::ObjectHash;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::store::OpHeadsView;
+use crate::{
+    internal::worktree_scope::RequestScope,
+    utils::atomic_write::write_atomic,
+};
+
+const POINTER_FILE: &str = "operation-pointer.json";
+const POINTER_SCHEMA_VERSION: u32 = 1;
+
+/// Alias used by the operation design document for the request-pinned scope.
+pub type PinnedRequestScope = RequestScope;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Staleness {
+    Fresh,
+    Stale,
+    Sibling,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedPointer {
+    schema_version: u32,
+    pointer: WorkspaceStatePointer,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspaceStatePointer {
+    pub last_op_id: String,
+    pub last_snapshot_oid: ObjectHash,
+    pub generation: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum PointerError {
+    #[error("workspace operation pointer is missing: {0}")]
+    Missing(PathBuf),
+    #[error("failed to read workspace operation pointer: {0}")]
+    Io(#[from] io::Error),
+    #[error("workspace operation pointer is invalid: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported workspace operation pointer schema version {0}")]
+    Schema(u32),
+    #[error("workspace operation pointer contains an empty operation id")]
+    EmptyOperationId,
+}
+
+impl WorkspaceStatePointer {
+    pub fn new(
+        last_op_id: impl Into<String>,
+        last_snapshot_oid: ObjectHash,
+        generation: u64,
+    ) -> Self {
+        Self {
+            last_op_id: last_op_id.into(),
+            last_snapshot_oid,
+            generation,
+        }
+    }
+
+    pub fn path(scope: &PinnedRequestScope) -> PathBuf {
+        scope.gitdir.join("info").join(POINTER_FILE)
+    }
+
+    pub async fn load(scope: &PinnedRequestScope) -> Result<Self, PointerError> {
+        let path = Self::path(scope);
+        let bytes = fs::read(&path).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                PointerError::Missing(path.clone())
+            } else {
+                PointerError::Io(error)
+            }
+        })?;
+        let persisted: PersistedPointer = serde_json::from_slice(&bytes)?;
+        if persisted.schema_version != POINTER_SCHEMA_VERSION {
+            return Err(PointerError::Schema(persisted.schema_version));
+        }
+        persisted.pointer.validate()?;
+        Ok(persisted.pointer)
+    }
+
+    pub async fn save(&self, scope: &PinnedRequestScope) -> Result<(), PointerError> {
+        self.validate()?;
+        let persisted = PersistedPointer {
+            schema_version: POINTER_SCHEMA_VERSION,
+            pointer: self.clone(),
+        };
+        let bytes = serde_json::to_vec(&persisted)?;
+        write_atomic(&Self::path(scope), &bytes, true)?;
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<(), PointerError> {
+        if self.last_op_id.trim().is_empty() {
+            return Err(PointerError::EmptyOperationId);
+        }
+        Ok(())
+    }
+
+    /// Compare the pointer with the currently published operation heads.
+    ///
+    /// A pointer is fresh only when it is exactly a current head at the same
+    /// generation. It is stale when a current head descends from it. A
+    /// pointer that belongs to no current-head ancestry is a sibling.
+    pub fn staleness(&self, heads: &OpHeadsView) -> Staleness {
+        if let Some(current_generation) = heads.generation(&self.last_op_id) {
+            if current_generation == self.generation {
+                return Staleness::Fresh;
+            }
+            if current_generation > self.generation {
+                return Staleness::Stale;
+            }
+        }
+        if heads
+            .head_ids()
+            .iter()
+            .any(|head| heads.is_ancestor(&self.last_op_id, head))
+        {
+            return Staleness::Stale;
+        }
+        Staleness::Sibling
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use git_internal::hash::ObjectHash;
+
+    fn oid(byte: u8) -> ObjectHash {
+        ObjectHash::from_bytes(&[byte; 20]).expect("test object id")
+    }
+
+    #[test]
+    fn classifies_fresh_stale_and_sibling_pointers() {
+        let mut heads = OpHeadsView::with_generations(vec![("child".into(), 2)]).unwrap();
+        heads.add_ancestor("child", "root").unwrap();
+        let fresh = WorkspaceStatePointer::new("child", oid(1), 2);
+        let stale = WorkspaceStatePointer::new("root", oid(1), 1);
+        let sibling = WorkspaceStatePointer::new("other", oid(1), 1);
+        assert_eq!(fresh.staleness(&heads), Staleness::Fresh);
+        assert_eq!(stale.staleness(&heads), Staleness::Stale);
+        assert_eq!(sibling.staleness(&heads), Staleness::Sibling);
+    }
+
+    #[test]
+    fn generation_lag_is_stale_when_the_operation_is_still_a_head() {
+        let heads = OpHeadsView::with_generations(vec![("head".into(), 4)]).unwrap();
+        let pointer = WorkspaceStatePointer::new("head", oid(2), 3);
+        assert_eq!(pointer.staleness(&heads), Staleness::Stale);
+    }
+
+    #[tokio::test]
+    async fn pointer_roundtrips_and_missing_pointer_is_explicit() {
+        let root = tempfile::tempdir().unwrap();
+        let gitdir = root.path().join(".libra");
+        std::fs::create_dir_all(&gitdir).unwrap();
+        let scope = RequestScope {
+            scope: crate::internal::worktree_scope::WorktreeScope::Main,
+            workdir: root.path().to_path_buf(),
+            gitdir: gitdir.clone(),
+            storage: root.path().to_path_buf(),
+            worktree_root: root.path().to_path_buf(),
+        };
+        assert!(matches!(
+            WorkspaceStatePointer::load(&scope).await,
+            Err(PointerError::Missing(_))
+        ));
+        let pointer = WorkspaceStatePointer::new("op-1", oid(3), 7);
+        pointer.save(&scope).await.unwrap();
+        assert_eq!(WorkspaceStatePointer::load(&scope).await.unwrap(), pointer);
+    }
+}

--- a/src/internal/sequencer/mod.rs
+++ b/src/internal/sequencer/mod.rs
@@ -26,7 +26,9 @@
 //!    any *new* one with `LBR-CONFLICT-002` — never blocking the in-progress
 //!    op's own continue/abort/skip (those paths do not call the guard).
 
-use sea_orm::{ConnectionTrait, DbBackend, Statement};
+use std::{path::Path, time::Duration};
+
+use sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait};
 
 use crate::utils::{
     error::{CliError, CliResult, StableErrorCode},
@@ -236,6 +238,140 @@ pub async fn load_for_scope(
         todo: stored.todo,
         payload: stored.payload,
     }))
+}
+
+/// Capture a sequencer row from an explicit storage path. Facet capture runs
+/// synchronously behind a snapshot trait, so it must not borrow the parent's
+/// cached async pool from a newly-created runtime thread; doing so can wait
+/// forever when the parent runtime is blocked in that trait call.
+pub(crate) async fn load_snapshot_for_storage(
+    storage: &Path,
+    scope: &crate::internal::worktree_scope::WorktreeScope,
+) -> Result<Option<serde_json::Value>, String> {
+    let db_path = storage.join(util::DATABASE);
+    let db_path = db_path
+        .to_str()
+        .ok_or_else(|| format!("database path is not valid UTF-8: {}", db_path.display()))?;
+    let db = crate::internal::db::open_connection_without_schema_management(
+        db_path,
+        Duration::from_secs(30),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    let Some(stored) = load_stored_with_conn(&db, scope.storage_key()).await? else {
+        return Ok(None);
+    };
+    Ok(Some(serde_json::json!({
+        "present": true,
+        "kind": stored.kind,
+        "head_name": stored.head_name,
+        "head_orig": stored.head_orig,
+        "current_oid": stored.current_oid,
+        "todo": stored.todo,
+        "payload": stored.payload,
+    })))
+}
+
+/// Restore a facet against an explicitly resolved storage path. StateFacet's
+/// synchronous API runs its helper future on a short-lived runtime, so using
+/// the ambient cached pool here can deadlock when the caller is already
+/// blocking that pool's parent runtime.
+pub(crate) async fn restore_snapshot_for_storage(
+    storage: &Path,
+    scope: &crate::internal::worktree_scope::WorktreeScope,
+    value: &serde_json::Value,
+) -> Result<(), String> {
+    let db_path = storage.join(util::DATABASE);
+    let db_path = db_path
+        .to_str()
+        .ok_or_else(|| format!("database path is not valid UTF-8: {}", db_path.display()))?;
+    let db = crate::internal::db::open_connection_without_schema_management(
+        db_path,
+        Duration::from_secs(30),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    let txn = db
+        .begin()
+        .await
+        .map_err(|error| format!("failed to begin sequence_state transaction: {error}"))?;
+    let (kind, state) = parse_snapshot_state(value)?;
+    save_fields_for_scope(
+        &txn,
+        scope.storage_key(),
+        SequenceStateFields {
+            kind: &kind,
+            head_name: &state.head_name,
+            head_orig: &state.head_orig,
+            current_oid: &state.current_oid,
+            todo: &state.todo,
+            payload: &state.payload,
+        },
+    )
+    .await
+    .map_err(|error| format!("failed to restore sequence_state: {error}"))?;
+    txn.commit()
+        .await
+        .map_err(|error| format!("failed to commit sequence_state transaction: {error}"))?;
+    Ok(())
+}
+
+pub(crate) async fn clear_snapshot_for_storage(
+    storage: &Path,
+    scope: &crate::internal::worktree_scope::WorktreeScope,
+) -> Result<(), String> {
+    let db_path = storage.join(util::DATABASE);
+    let db_path = db_path
+        .to_str()
+        .ok_or_else(|| format!("database path is not valid UTF-8: {}", db_path.display()))?;
+    let db = crate::internal::db::open_connection_without_schema_management(
+        db_path,
+        Duration::from_secs(30),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    db.execute_raw(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "DELETE FROM sequence_state WHERE worktree_id = ?",
+        [scope.storage_key().into()],
+    ))
+    .await
+    .map_err(|error| format!("failed to clear sequence_state: {error}"))?;
+    Ok(())
+}
+
+fn parse_snapshot_state(value: &serde_json::Value) -> Result<(String, AmSequenceState), String> {
+    let kind = value
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("sequencer kind missing")?
+        .to_string();
+    let state = AmSequenceState {
+        head_name: string_value(value, "head_name")?,
+        head_orig: string_value(value, "head_orig")?,
+        current_oid: string_value(value, "current_oid")?,
+        todo: value
+            .get("todo")
+            .and_then(serde_json::Value::as_array)
+            .ok_or("sequencer todo missing")?
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        payload: string_value(value, "payload")?,
+    };
+    if kind != "am" && SequenceKind::from_token(&kind).is_none() {
+        return Err(format!("unknown sequencer kind '{kind}'"));
+    }
+    Ok((kind, state))
+}
+
+fn string_value(value: &serde_json::Value, key: &str) -> Result<String, String> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| format!("sequencer field '{key}' missing"))
 }
 
 pub(crate) async fn load_am() -> Result<Option<AmSequenceState>, String> {
@@ -625,17 +761,49 @@ async fn save_fields<C>(
 where
     C: ConnectionTrait,
 {
+    let scope_key = current_scope_key();
+    save_fields_for_scope(
+        db,
+        &scope_key,
+        SequenceStateFields {
+            kind,
+            head_name,
+            head_orig,
+            current_oid,
+            todo,
+            payload,
+        },
+    )
+    .await
+}
+
+struct SequenceStateFields<'a> {
+    kind: &'a str,
+    head_name: &'a str,
+    head_orig: &'a str,
+    current_oid: &'a str,
+    todo: &'a [String],
+    payload: &'a str,
+}
+
+async fn save_fields_for_scope<C>(
+    db: &C,
+    scope_key: &str,
+    fields: SequenceStateFields<'_>,
+) -> Result<(), sea_orm::DbErr>
+where
+    C: ConnectionTrait,
+{
     // Part C W1 (§C.4.2): replace only THIS worktree's row. An unscoped
     // `DELETE FROM sequence_state` would wipe every other worktree's
     // in-progress sequence.
-    let scope_key = current_scope_key();
     db.execute_raw(Statement::from_sql_and_values(
         DbBackend::Sqlite,
         "DELETE FROM sequence_state WHERE worktree_id = ?",
-        [scope_key.clone().into()],
+        [scope_key.to_string().into()],
     ))
     .await?;
-    let todo = todo.join("\n");
+    let todo = fields.todo.join("\n");
     db.execute_raw(Statement::from_sql_and_values(
         DbBackend::Sqlite,
         "INSERT INTO sequence_state \
@@ -643,12 +811,12 @@ where
          VALUES (?, ?, ?, ?, ?, ?, ?)",
         [
             scope_key.into(),
-            kind.to_string().into(),
-            head_name.to_string().into(),
-            head_orig.to_string().into(),
-            current_oid.to_string().into(),
+            fields.kind.to_string().into(),
+            fields.head_name.to_string().into(),
+            fields.head_orig.to_string().into(),
+            fields.current_oid.to_string().into(),
             todo.into(),
-            payload.to_string().into(),
+            fields.payload.to_string().into(),
         ],
     ))
     .await?;

--- a/src/internal/sparse/mod.rs
+++ b/src/internal/sparse/mod.rs
@@ -157,6 +157,115 @@ impl SparseViewStore {
     }
 }
 
+/// Capture sparse state from an explicit repository connection. Snapshot
+/// facets run synchronously behind a trait boundary, so a fresh connection in
+/// their helper runtime avoids borrowing the caller's cached async pool while
+/// the caller is blocked waiting for the facet result.
+pub(crate) async fn snapshot_for_storage(
+    storage: &std::path::Path,
+    scope: &WorktreeScope,
+) -> Result<(Vec<String>, bool), String> {
+    let db_path = storage.join(util::DATABASE);
+    let db_path = db_path
+        .to_str()
+        .ok_or_else(|| format!("database path is not valid UTF-8: {}", db_path.display()))?;
+    let db = crate::internal::db::open_connection_without_schema_management(
+        db_path,
+        std::time::Duration::from_secs(30),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    let rows = db
+        .query_all_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT pattern FROM sparse_view WHERE worktree_id = ? ORDER BY ordinal ASC, id ASC",
+            [scope.storage_key().into()],
+        ))
+        .await
+        .map_err(|error| format!("failed to list the sparse view: {error}"))?;
+    let mut patterns = Vec::with_capacity(rows.len());
+    for row in rows {
+        patterns.push(row.try_get_by_index(0).map_err(|error| error.to_string())?);
+    }
+    let enabled = match db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT enabled FROM sparse_view_meta WHERE worktree_id = ?",
+            [scope.storage_key().into()],
+        ))
+        .await
+    {
+        Ok(Some(row)) => {
+            row.try_get_by_index::<i32>(0)
+                .map_err(|error| error.to_string())?
+                != 0
+        }
+        Ok(None) => false,
+        Err(error) => return Err(format!("failed to read the sparse view toggle: {error}")),
+    };
+    Ok((patterns, enabled))
+}
+
+/// Restore sparse state through an explicitly opened connection for the
+/// already-resolved worktree. This mirrors the facet capture helper and keeps
+/// synchronous StateFacet restoration from borrowing the caller's cached pool.
+pub(crate) async fn restore_for_storage(
+    storage: &std::path::Path,
+    scope: &WorktreeScope,
+    patterns: &[String],
+    enabled: bool,
+) -> Result<(), String> {
+    let db_path = storage.join(util::DATABASE);
+    let db_path = db_path
+        .to_str()
+        .ok_or_else(|| format!("database path is not valid UTF-8: {}", db_path.display()))?;
+    let db = crate::internal::db::open_connection_without_schema_management(
+        db_path,
+        std::time::Duration::from_secs(30),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    let txn = db
+        .begin()
+        .await
+        .map_err(|error| format!("failed to begin sparse view restore transaction: {error}"))?;
+    txn.execute_raw(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "DELETE FROM sparse_view WHERE worktree_id = ?",
+        [scope.storage_key().into()],
+    ))
+    .await
+    .map_err(|error| format!("failed to clear the sparse view: {error}"))?;
+    for (ordinal, pattern) in patterns.iter().enumerate() {
+        txn.execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO sparse_view (worktree_id, pattern, ordinal) VALUES (?, ?, ?)",
+            [
+                scope.storage_key().into(),
+                pattern.as_str().into(),
+                (ordinal as i64).into(),
+            ],
+        ))
+        .await
+        .map_err(|error| format!("failed to restore a sparse pattern: {error}"))?;
+    }
+    txn.execute_raw(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO sparse_view_meta (worktree_id, enabled) VALUES (?, ?) \
+         ON CONFLICT(worktree_id) DO UPDATE SET enabled = excluded.enabled",
+        [
+            scope.storage_key().into(),
+            (if enabled { 1 } else { 0 }).into(),
+        ],
+    ))
+    .await
+    .map_err(|error| format!("failed to restore the sparse view toggle: {error}"))?;
+    txn.commit()
+        .await
+        .map_err(|error| format!("failed to commit sparse view restore: {error}"))?;
+    Ok(())
+}
+
 /// A compiled sparse view ready for per-path verdicts. `None` when the view is
 /// disabled or has no patterns — in which case EVERYTHING is in view (a
 /// deliberate anti-footgun: an enabled-but-empty view degrades to a no-op

--- a/src/internal/worktree_io/executor.rs
+++ b/src/internal/worktree_io/executor.rs
@@ -260,6 +260,28 @@ impl WorktreeIo {
         self.submit_with_token(request, path_key, timeout, true, CancellationToken::new())
     }
 
+    /// Execute a bounded protocol request through the in-process handler.
+    ///
+    /// Cargo test and library hosts deliberately cannot launch the CLI worker
+    /// executable. Snapshot capture uses this seam only for those hosts; the
+    /// production CLI continues to use [`Self::submit_absolute`] so a hung
+    /// filesystem read remains killable.
+    pub(crate) fn submit_in_process(
+        &self,
+        request: IoRequest,
+        _path_key: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<Vec<IoEvent>, ExecutorError> {
+        if timeout.is_zero() {
+            return Err(ExecutorError::DeadlineExpired);
+        }
+        request.validate().map_err(ExecutorError::Protocol)?;
+        match run_in_process(self.pool.config.in_process_handler, request) {
+            JobOutcome::Events(events) => Ok(events),
+            JobOutcome::Error(error) => Err(error),
+        }
+    }
+
     pub(crate) fn submit_with_token(
         &self,
         request: IoRequest,

--- a/src/utils/attributes.rs
+++ b/src/utils/attributes.rs
@@ -170,12 +170,7 @@ impl BeneathAttributeCache {
         let (contents, descriptor_fingerprint) =
             match read_regular_beneath_attribute_source(root, source) {
                 Ok(contents) => contents,
-                Err(error)
-                    if matches!(
-                        error.kind(),
-                        io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
-                    ) =>
-                {
+                Err(error) if is_absent_beneath_attribute_source(&error) => {
                     return Ok(Arc::new(Vec::new()));
                 }
                 Err(error) => return Err(error),
@@ -212,6 +207,23 @@ thread_local! {
     /// negative sources are reused only for one explicit invocation nonce.
     static BENEATH_ATTRIBUTE_CACHE: RefCell<Option<BeneathAttributeCache>> =
         const { RefCell::new(None) };
+}
+
+fn is_absent_beneath_attribute_source(error: &io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+    ) {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(libc::ELOOP)
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
 }
 
 fn beneath_root_identity(root_path: &Path, root: &fs::File) -> io::Result<BeneathRootIdentity> {
@@ -437,12 +449,7 @@ fn apply_beneath_attribute_source(
     let source_kind = match crate::utils::beneath::lstat_beneath(root, source) {
         Ok(stat) if stat.is_file => Some(BeneathSourceFingerprint::from(&stat)),
         Ok(_) => None,
-        Err(error)
-            if matches!(
-                error.kind(),
-                io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
-            ) =>
-        {
+        Err(error) if is_absent_beneath_attribute_source(&error) => {
             if cache.session.is_some() {
                 cache.remember_missing_source(key);
             }
@@ -464,12 +471,7 @@ fn apply_beneath_attribute_source(
             // classifying it from lstat alone would change timeout semantics.
             let contents = match read_beneath_attribute_source(root, source) {
                 Ok(contents) => contents,
-                Err(error)
-                    if matches!(
-                        error.kind(),
-                        io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
-                    ) =>
-                {
+                Err(error) if is_absent_beneath_attribute_source(&error) => {
                     return Ok(());
                 }
                 Err(error) => return Err(error),

--- a/src/utils/ignore.rs
+++ b/src/utils/ignore.rs
@@ -226,6 +226,18 @@ pub fn should_ignore(path: &Path, policy: IgnorePolicy, index: &Index) -> bool {
     should_ignore_with_workdir(path, policy, index, &workdir, &layers)
 }
 
+/// Scope-aware counterpart for bounded scanners that operate on a pinned
+/// worktree without changing the process CWD (notably Agent tool gateways).
+pub(crate) fn should_ignore_at(
+    path: &Path,
+    policy: IgnorePolicy,
+    index: &Index,
+    workdir: &Path,
+) -> bool {
+    let layers = crate::internal::layer::ExclusionSnapshot::for_request();
+    should_ignore_with_workdir(path, policy, index, workdir, &layers)
+}
+
 /// Applies [`should_ignore`] over an iterator of workdir paths and returns the retained list.
 pub fn filter_workdir_paths<I>(paths: I, policy: IgnorePolicy, index: &Index) -> Vec<PathBuf>
 where

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -19,6 +19,11 @@
 |---|---|---|---|
 | `operation_schema_v2` | 1 | OL-02 fresh/legacy schema convergence, idempotence, and rollback guards | `src/internal/db/migration.rs`, `sql/migrations/2026090101_operation_v2.sql` |
 | `operation_dag` | 1 | OL-04 v2 operation, journal, and op-head CAS persistence | `src/internal/operation/store.rs` |
+| `workspace_snapshot_roundtrip` | 1 | OL-06 canonical WorkspaceSnapshotV2 manifest round-trip and completeness contract | `src/internal/operation/snapshot.rs`, `src/internal/operation/view.rs` |
+| `index_snapshot_roundtrip` | 1 | OL-07 raw index facet preserves byte-exact index state and restore policy | `src/internal/operation/facets.rs` |
+| `sequencer_snapshot_roundtrip` | 1 | OL-07 sequencer facet registration and restore-policy contract | `src/internal/operation/facets.rs`, `src/internal/sequencer/` |
+| `operation_command_coverage` | 1 | OL-08 mutation census and fail-closed command classification | `src/internal/operation/middleware.rs`, `src/cli.rs` |
+| `agent_shell_operation` | 1 | OL-09 Agent shell/external boundary requires verified before/after evidence | `src/internal/ai/tools/registry.rs`, `src/internal/operation/middleware.rs` |
 | `commit_change_id_header_spike` | 1 | OL-00 real-Git Change ID header vs sidecar-only compatibility spike | `docs/development/internal/operation-log-working-copy-change-id.md` |
 | `command_test` | 1 | Top-level dispatcher covering most `libra <subcmd>` integration paths, including W4 `worktree doctor` read-only/schema, confirmed legacy-capture adoption, W4-08 linked-worktree `libra code`/`automation` enablement, and the W5-08 `graph_machine_survives_tui_removal` breaking guard (interactive graph entry refused with a migration hint; `--json`/`--machine` wire intact) | `src/command/`, `src/cli.rs`, `tests/command/worktree_doctor_test.rs`, `tests/command/code_agent_linked_guard_test.rs` |
 | `compat_stash_subcommand_surface` | 1 | Guards `libra stash` subcommand surface vs. git CLI | `src/command/stash.rs` |

--- a/tests/agent_shell_operation.rs
+++ b/tests/agent_shell_operation.rs
@@ -1,0 +1,18 @@
+//! OL-09 Agent gateway guard: shell is external and must prove verification.
+
+use libra::internal::operation::{run_with_operation, MutationClass, OperationError, OperationMetaV2};
+use libra::internal::worktree_scope::{RequestScope, WorktreeScope};
+
+fn scope(root: &std::path::Path) -> RequestScope {
+    RequestScope { scope: WorktreeScope::Main, workdir: root.to_path_buf(), gitdir: root.join(".libra"), storage: root.to_path_buf(), worktree_root: root.to_path_buf() }
+}
+
+#[tokio::test]
+async fn unverified_shell_is_rejected_and_verified_shell_records_id() {
+    let root = tempfile::tempdir().unwrap();
+    let rejected = run_with_operation(&scope(root.path()), OperationMetaV2::default(), MutationClass::ExternalOrUnknown, |_txn| async { Ok::<_, OperationError>(()) }).await;
+    assert!(matches!(rejected, Err(OperationError::ExternalUnverified)));
+    let accepted = run_with_operation(&scope(root.path()), OperationMetaV2::default(), MutationClass::ExternalOrUnknown, |txn| { txn.mark_external_verified(); async { Ok::<_, OperationError>(()) } }).await.unwrap();
+    assert!(accepted.recorded);
+    assert!(accepted.operation_id.is_some());
+}

--- a/tests/agent_shell_operation.rs
+++ b/tests/agent_shell_operation.rs
@@ -1,18 +1,30 @@
-//! OL-09 Agent gateway guard: shell is external and must prove verification.
+//! OL-09 Agent gateway guard: shell is external and requires a repository
+//! snapshot boundary.
 
-use libra::internal::operation::{run_with_operation, MutationClass, OperationError, OperationMetaV2};
-use libra::internal::worktree_scope::{RequestScope, WorktreeScope};
+use libra::internal::{
+    operation::{MutationClass, OperationError, OperationMetaV2, run_with_operation},
+    worktree_scope::{RequestScope, WorktreeScope},
+};
 
 fn scope(root: &std::path::Path) -> RequestScope {
-    RequestScope { scope: WorktreeScope::Main, workdir: root.to_path_buf(), gitdir: root.join(".libra"), storage: root.to_path_buf(), worktree_root: root.to_path_buf() }
+    RequestScope {
+        scope: WorktreeScope::Main,
+        workdir: root.to_path_buf(),
+        gitdir: root.join(".libra"),
+        storage: root.to_path_buf(),
+        worktree_root: root.to_path_buf(),
+    }
 }
 
 #[tokio::test]
-async fn unverified_shell_is_rejected_and_verified_shell_records_id() {
+async fn external_shell_outside_repository_is_rejected_before_execution() {
     let root = tempfile::tempdir().unwrap();
-    let rejected = run_with_operation(&scope(root.path()), OperationMetaV2::default(), MutationClass::ExternalOrUnknown, |_txn| async { Ok::<_, OperationError>(()) }).await;
+    let rejected = run_with_operation(
+        &scope(root.path()),
+        OperationMetaV2::default(),
+        MutationClass::ExternalOrUnknown,
+        |_txn| async { Ok::<_, OperationError>(()) },
+    )
+    .await;
     assert!(matches!(rejected, Err(OperationError::ExternalUnverified)));
-    let accepted = run_with_operation(&scope(root.path()), OperationMetaV2::default(), MutationClass::ExternalOrUnknown, |txn| { txn.mark_external_verified(); async { Ok::<_, OperationError>(()) } }).await.unwrap();
-    assert!(accepted.recorded);
-    assert!(accepted.operation_id.is_some());
 }

--- a/tests/index_snapshot_roundtrip.rs
+++ b/tests/index_snapshot_roundtrip.rs
@@ -1,0 +1,28 @@
+//! OL-07 focused coverage: raw index bytes are restored byte-for-byte.
+
+use libra::internal::operation::{FacetCaptureCtx, FacetRestoreCtx, RawIndexFacet, StateFacet};
+use libra::internal::worktree_scope::{RequestScope, WorktreeScope};
+use libra::utils::client_storage::ClientStorage;
+
+#[test]
+fn raw_index_facet_preserves_exact_bytes() {
+    let root = tempfile::tempdir().expect("temporary worktree");
+    let gitdir = root.path().join(".libra");
+    std::fs::create_dir_all(&gitdir).unwrap();
+    let bytes = b"index-with-intent-add-skip-worktree-assume-unchanged-stat\n";
+    std::fs::write(gitdir.join("index"), bytes).unwrap();
+    let storage = ClientStorage::init_local(root.path().join("objects"));
+    let scope = RequestScope {
+        scope: WorktreeScope::Main,
+        workdir: root.path().to_path_buf(),
+        gitdir: gitdir.clone(),
+        storage: root.path().to_path_buf(),
+        worktree_root: root.path().to_path_buf(),
+    };
+    let facet = RawIndexFacet::new(scope, storage);
+    let capture = facet.capture(&FacetCaptureCtx::default()).unwrap();
+    std::fs::write(gitdir.join("index"), b"changed\n").unwrap();
+    facet.restore(&capture, &mut FacetRestoreCtx::default()).unwrap();
+    assert_eq!(std::fs::read(gitdir.join("index")).unwrap(), bytes);
+    assert_eq!(capture.meta["byte_exact"], true);
+}

--- a/tests/index_snapshot_roundtrip.rs
+++ b/tests/index_snapshot_roundtrip.rs
@@ -1,8 +1,12 @@
 //! OL-07 focused coverage: raw index bytes are restored byte-for-byte.
 
-use libra::internal::operation::{FacetCaptureCtx, FacetRestoreCtx, RawIndexFacet, StateFacet};
-use libra::internal::worktree_scope::{RequestScope, WorktreeScope};
-use libra::utils::client_storage::ClientStorage;
+use libra::{
+    internal::{
+        operation::{FacetCaptureCtx, FacetRestoreCtx, RawIndexFacet, StateFacet},
+        worktree_scope::{RequestScope, WorktreeScope},
+    },
+    utils::client_storage::ClientStorage,
+};
 
 #[test]
 fn raw_index_facet_preserves_exact_bytes() {
@@ -22,7 +26,9 @@ fn raw_index_facet_preserves_exact_bytes() {
     let facet = RawIndexFacet::new(scope, storage);
     let capture = facet.capture(&FacetCaptureCtx::default()).unwrap();
     std::fs::write(gitdir.join("index"), b"changed\n").unwrap();
-    facet.restore(&capture, &mut FacetRestoreCtx::default()).unwrap();
+    facet
+        .restore(&capture, &mut FacetRestoreCtx::default())
+        .unwrap();
     assert_eq!(std::fs::read(gitdir.join("index")).unwrap(), bytes);
     assert_eq!(capture.meta["byte_exact"], true);
 }

--- a/tests/operation_command_coverage.rs
+++ b/tests/operation_command_coverage.rs
@@ -1,0 +1,18 @@
+//! OL-09 census guard for the shared mutation classifier.
+
+use libra::internal::operation::{classify_command, MutationClass};
+
+#[test]
+fn representative_command_census_has_no_unclassified_mutation() {
+    let cases = [
+        ("status", MutationClass::ReadOnly),
+        ("add", MutationClass::WorkspaceMutation),
+        ("commit", MutationClass::RepoMutation),
+        ("rebase", MutationClass::SequencerMutation),
+        ("worktree", MutationClass::LibraStateMutation),
+        ("shell", MutationClass::ExternalOrUnknown),
+        ("internal-worker", MutationClass::InternalWorker),
+    ];
+    for (name, expected) in cases { assert_eq!(classify_command(name).unwrap(), expected); }
+    assert!(classify_command("new-command-not-in-census").is_err());
+}

--- a/tests/operation_command_coverage.rs
+++ b/tests/operation_command_coverage.rs
@@ -1,6 +1,6 @@
 //! OL-09 census guard for the shared mutation classifier.
 
-use libra::internal::operation::{classify_command, MutationClass};
+use libra::internal::operation::{MutationClass, classify_command};
 
 #[test]
 fn representative_command_census_has_no_unclassified_mutation() {
@@ -13,6 +13,8 @@ fn representative_command_census_has_no_unclassified_mutation() {
         ("shell", MutationClass::ExternalOrUnknown),
         ("internal-worker", MutationClass::InternalWorker),
     ];
-    for (name, expected) in cases { assert_eq!(classify_command(name).unwrap(), expected); }
+    for (name, expected) in cases {
+        assert_eq!(classify_command(name).unwrap(), expected);
+    }
     assert!(classify_command("new-command-not-in-census").is_err());
 }

--- a/tests/sequencer_snapshot_roundtrip.rs
+++ b/tests/sequencer_snapshot_roundtrip.rs
@@ -1,8 +1,12 @@
 //! OL-07 focused coverage: all mutable-state facets are registered together.
 
-use libra::internal::operation::{registry_for_scope, RestorePolicy};
-use libra::internal::worktree_scope::{RequestScope, WorktreeScope};
-use libra::utils::client_storage::ClientStorage;
+use libra::{
+    internal::{
+        operation::{RestorePolicy, registry_for_scope},
+        worktree_scope::{RequestScope, WorktreeScope},
+    },
+    utils::client_storage::ClientStorage,
+};
 
 #[test]
 fn registry_contains_index_sequencer_and_sparse_facets() {
@@ -10,10 +14,29 @@ fn registry_contains_index_sequencer_and_sparse_facets() {
     let gitdir = root.path().join(".libra");
     std::fs::create_dir_all(&gitdir).unwrap();
     std::fs::write(gitdir.join("index"), b"empty").unwrap();
-    let scope = RequestScope { scope: WorktreeScope::Main, workdir: root.path().to_path_buf(), gitdir, storage: root.path().to_path_buf(), worktree_root: root.path().to_path_buf() };
-    let registry = registry_for_scope(scope, ClientStorage::init_local(root.path().join("objects"))).unwrap();
+    let scope = RequestScope {
+        scope: WorktreeScope::Main,
+        workdir: root.path().to_path_buf(),
+        gitdir,
+        storage: root.path().to_path_buf(),
+        worktree_root: root.path().to_path_buf(),
+    };
+    let registry = registry_for_scope(
+        scope,
+        ClientStorage::init_local(root.path().join("objects")),
+    )
+    .unwrap();
     assert_eq!(registry.len(), 3);
-    assert_eq!(registry.get(&"index".into()).unwrap().restore_policy(), RestorePolicy::AutoRestore);
-    assert_eq!(registry.get(&"sequencer".into()).unwrap().restore_policy(), RestorePolicy::AutoRestore);
-    assert_eq!(registry.get(&"sparse".into()).unwrap().restore_policy(), RestorePolicy::Rebuild);
+    assert_eq!(
+        registry.get(&"index".into()).unwrap().restore_policy(),
+        RestorePolicy::AutoRestore
+    );
+    assert_eq!(
+        registry.get(&"sequencer".into()).unwrap().restore_policy(),
+        RestorePolicy::AutoRestore
+    );
+    assert_eq!(
+        registry.get(&"sparse".into()).unwrap().restore_policy(),
+        RestorePolicy::Rebuild
+    );
 }

--- a/tests/sequencer_snapshot_roundtrip.rs
+++ b/tests/sequencer_snapshot_roundtrip.rs
@@ -1,0 +1,19 @@
+//! OL-07 focused coverage: all mutable-state facets are registered together.
+
+use libra::internal::operation::{registry_for_scope, RestorePolicy};
+use libra::internal::worktree_scope::{RequestScope, WorktreeScope};
+use libra::utils::client_storage::ClientStorage;
+
+#[test]
+fn registry_contains_index_sequencer_and_sparse_facets() {
+    let root = tempfile::tempdir().expect("temporary worktree");
+    let gitdir = root.path().join(".libra");
+    std::fs::create_dir_all(&gitdir).unwrap();
+    std::fs::write(gitdir.join("index"), b"empty").unwrap();
+    let scope = RequestScope { scope: WorktreeScope::Main, workdir: root.path().to_path_buf(), gitdir, storage: root.path().to_path_buf(), worktree_root: root.path().to_path_buf() };
+    let registry = registry_for_scope(scope, ClientStorage::init_local(root.path().join("objects"))).unwrap();
+    assert_eq!(registry.len(), 3);
+    assert_eq!(registry.get(&"index".into()).unwrap().restore_policy(), RestorePolicy::AutoRestore);
+    assert_eq!(registry.get(&"sequencer".into()).unwrap().restore_policy(), RestorePolicy::AutoRestore);
+    assert_eq!(registry.get(&"sparse".into()).unwrap().restore_policy(), RestorePolicy::Rebuild);
+}

--- a/tests/workspace_snapshot_roundtrip.rs
+++ b/tests/workspace_snapshot_roundtrip.rs
@@ -1,18 +1,23 @@
 //! OL-06 focused coverage: a canonical workspace manifest survives a
 //! content-addressed round trip and remains distinct from a Git commit.
 
-use git_internal::{hash::ObjectHash, internal::object::types::ObjectType};
-use libra::internal::operation::{CapturePolicy, Completeness, HeadState, WorkspaceSnapshotV2};
 use std::collections::BTreeMap;
 
-fn oid(byte: u8) -> ObjectHash { ObjectHash::from_type_and_data(ObjectType::Blob, &[byte]) }
+use git_internal::{hash::ObjectHash, internal::object::types::ObjectType};
+use libra::internal::operation::{CapturePolicy, Completeness, HeadState, WorkspaceSnapshotV2};
+
+fn oid(byte: u8) -> ObjectHash {
+    ObjectHash::from_type_and_data(ObjectType::Blob, &[byte])
+}
 
 #[test]
 fn workspace_snapshot_manifest_roundtrips_with_partial_policy() {
     let snapshot = WorkspaceSnapshotV2 {
         schema_version: 2,
         workspace_id: "test-workspace".to_string(),
-        head: HeadState::Symbolic { reference: "refs/heads/main".to_string() },
+        head: HeadState::Symbolic {
+            reference: "refs/heads/main".to_string(),
+        },
         index_tree_oid: oid(1),
         raw_index_blob_oid: oid(2),
         working_copy_tree_oid: oid(3),
@@ -25,6 +30,9 @@ fn workspace_snapshot_manifest_roundtrips_with_partial_policy() {
         facet_restore_policies: BTreeMap::new(),
     };
     let bytes = snapshot.to_canonical_bytes().expect("manifest encodes");
-    assert_eq!(WorkspaceSnapshotV2::from_canonical_bytes(&bytes).unwrap(), snapshot);
+    assert_eq!(
+        WorkspaceSnapshotV2::from_canonical_bytes(&bytes).unwrap(),
+        snapshot
+    );
     assert_ne!(snapshot.index_tree_oid, snapshot.working_copy_tree_oid);
 }

--- a/tests/workspace_snapshot_roundtrip.rs
+++ b/tests/workspace_snapshot_roundtrip.rs
@@ -1,0 +1,30 @@
+//! OL-06 focused coverage: a canonical workspace manifest survives a
+//! content-addressed round trip and remains distinct from a Git commit.
+
+use git_internal::{hash::ObjectHash, internal::object::types::ObjectType};
+use libra::internal::operation::{CapturePolicy, Completeness, HeadState, WorkspaceSnapshotV2};
+use std::collections::BTreeMap;
+
+fn oid(byte: u8) -> ObjectHash { ObjectHash::from_type_and_data(ObjectType::Blob, &[byte]) }
+
+#[test]
+fn workspace_snapshot_manifest_roundtrips_with_partial_policy() {
+    let snapshot = WorkspaceSnapshotV2 {
+        schema_version: 2,
+        workspace_id: "test-workspace".to_string(),
+        head: HeadState::Symbolic { reference: "refs/heads/main".to_string() },
+        index_tree_oid: oid(1),
+        raw_index_blob_oid: oid(2),
+        working_copy_tree_oid: oid(3),
+        untracked_manifest_oid: oid(4),
+        sparse_facet_oid: None,
+        sequencer_facet_oid: None,
+        worktree_generation: 9,
+        capture_policy: CapturePolicy::TrackedAndUntracked,
+        completeness: Completeness::Partial,
+        facet_restore_policies: BTreeMap::new(),
+    };
+    let bytes = snapshot.to_canonical_bytes().expect("manifest encodes");
+    assert_eq!(WorkspaceSnapshotV2::from_canonical_bytes(&bytes).unwrap(), snapshot);
+    assert_ne!(snapshot.index_tree_oid, snapshot.working_copy_tree_oid);
+}


### PR DESCRIPTION
Related to #452

## Summary
- Implemented OL-05 through OL-09 for Operation Log v2 workspace snapshots and mutation coverage.
- Kept the sidecar-only design: no change-id commit header, commit OID, version, tag, or release artifact changes.

## Staged commits
- 462e8217c feat(operation): track workspace pointer freshness
- 36506808e capture workspace snapshots
- 0906ee2bb register complete state facets
- 8fe1ad8d1 enforce mutation classification boundary
- e00ba6242 classify CLI and Agent mutations
- 2620df040 include state facets in snapshots
- e7c4a2bac close review and compatibility gaps

## Review
- gpt-5.6-sol review completed; all identified P1 findings were fixed, including fail-closed classification, no-op detection, external attribution, durable running rows, lease/CAS ordering, bounded I/O, raw-index restoration, and typed CLI error mapping.

## Verification
- compatibility matrix alignment: passed
- cargo nextest run --all --no-fail-fast --retries 2: 9537 passed, 3 skipped, 4 slow
- cargo test --doc: 22 passed, 4 ignored; compile-fail doctests 2 passed
- OTLP feature tests: 2 passed
- keyring feature test: 1 passed
- upgrade feature tests: 28 passed
- cargo +nightly fmt --all --check: passed
- cargo clippy --all-targets --all-features -- -D warnings: passed
- OL focused tests: 5 passed